### PR TITLE
feat(dialect): D1 — Dialect enum + SQL type-mapping table

### DIFF
--- a/.claude/plans/db-target-types-d1.plan.md
+++ b/.claude/plans/db-target-types-d1.plan.md
@@ -1,0 +1,178 @@
+# Plan: Database-Target Types — D1 (`Dialect` Enum + Type-Mapping Table)
+
+**Source PRD**: `.claude/prds/db-target-types.prd.md`
+**Selected Milestone**: D1 — `Dialect` enum + complete type-mapping table + unit tests (no I/O)
+**Target branch**: `feature/db-targets-d1` (cut from `main`; can land independently of `feature/erd-v2`)
+**Complexity**: Small
+
+## Summary
+
+Land the foundational `Dialect` enum and the full `gencsv-type × dialect → SQL-type-string` mapping table from PRD §6.2 as a pure-library module with no I/O, no CLI changes, no `Output` sink. This milestone is a lookup table behind a small API; everything else (DDL emission, load commands, Parquet logical types, ER integration) is layered on top of it in D2–D5. Choosing to land this independently of the ER work is deliberate — D1 has zero behavioural overlap with ER and no shared files, so it can ship in parallel.
+
+## Patterns to Mirror
+
+| Category | Source | Pattern |
+|---|---|---|
+| Sub-module re-export | `src/util/mod.rs` | Add `pub mod dialect;` alongside `schema`, `fake`, `dataframe`, `output` |
+| Error type | `src/lib.rs:7` | `Box<dyn Error>` via `format!("...: {e}")` context — repo convention, NOT `thiserror` (see CLAUDE.md "Error handling") |
+| Inline test module (no `#[cfg(test)]`) | `src/util/schema.rs:58-93`, `src/util/fake.rs:270-…` | `mod test { #![allow(unused_imports)] use super::*; ... }` per CLAUDE.md convention |
+| Match-based dispatch over type strings | `src/util/fake.rs:60-90` `create_column` | `match element.datatype.as_str() { "INT" => …, "STRING" => …, _ => fall-through }` — keep the same shape so a future reader can pattern-match between the two tables |
+| Enum + `as_str()` / `from_str` pair | None in this repo yet — clean greenfield | Use `#[derive(clap::ValueEnum)]` so D2/CLI work in a later milestone can attach `--target` flag with zero refactor |
+| String literals over `&'static str` constants | `src/util/fake.rs:60` (type strings inline) | Keep mapping table values inline; don't pre-allocate `const POSTGRES_INT: &str = "INTEGER"` constants until something needs them by name |
+
+## Requirements Restatement
+
+Build a single new file `src/util/dialect.rs` that exposes:
+
+```rust
+pub enum Dialect { Mysql, Postgres, Sqlserver, Bigquery, Spark }
+
+impl Dialect {
+    pub fn as_str(&self) -> &'static str;   // "mysql" | "postgres" | ...
+    pub fn from_str(s: &str) -> Result<Self, DialectError>;
+}
+
+pub struct DialectError { pub message: String }   // Display + Error
+
+pub fn to_sql_type(gencsv_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError>;
+```
+
+All 24 rows in PRD §6.2 must be covered. `is_pk` only changes the output for `INT_INC` (per the PRD table: PK gets `INT AUTO_INCREMENT PRIMARY KEY` / `SERIAL PRIMARY KEY` / etc., non-PK gets `INT NOT NULL` / `INTEGER NOT NULL` / etc.). For all other types, `is_pk` is accepted but ignored — we don't decorate non-`INT_INC` PKs in D1.
+
+Unknown `gencsv_type` returns `Err(DialectError { message: "type 'foo' has no '{dialect}' mapping; supported mappings: see docs/DIALECTS.md" })` per PRD §7. The `docs/DIALECTS.md` reference is forward-looking — file lands in D6, but the error string must be present from D1 so we don't need to update it later.
+
+**Explicitly NOT in D1**: no `Output` trait impl, no file emission, no CLI flag, no DDL string assembly (`CREATE TABLE ...`), no load-command rendering, no Parquet logical-type wiring, no schema.rs changes. Those are D2–D5.
+
+## Files to Change
+
+| File | Action | Why |
+|---|---|---|
+| `src/util/dialect.rs` | CREATE | The whole milestone — `Dialect` enum + mapping function + inline unit tests |
+| `src/util/mod.rs` | UPDATE | `pub mod dialect;` |
+| `Cargo.toml` | UPDATE (maybe) | Only if `clap::ValueEnum` derive needs the `derive` feature — already enabled (`clap = { version = "4.5", features = ["derive"] }` per CLAUDE.md). Likely no change. |
+
+No changes to `src/main.rs`, `src/lib.rs`, `src/util/schema.rs`, `src/util/fake.rs`, `src/util/dataframe.rs`, `src/util/output.rs`, `tests/cli.rs`. D1 is purely additive at the library level.
+
+## Tasks (TDD order — RED → GREEN → REFACTOR)
+
+### Task 1: Branch
+- **Action**: `git checkout -b feature/db-targets-d1` from `main`.
+- **Validate**: `git status` clean; on new branch.
+
+### Task 2: Module skeleton + `Dialect` enum + failing tests
+- **Action**: Create `src/util/dialect.rs` with:
+  - `#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)] pub enum Dialect { Mysql, Postgres, Sqlserver, Bigquery, Spark }`
+  - `pub struct DialectError { pub message: String }` with `Display` + `Error` impls
+  - `impl Dialect { pub fn as_str(&self) -> &'static str { ... } pub fn from_str(s: &str) -> Result<Self, DialectError> { ... } }` — body for `as_str` is the only thing implemented; `from_str` and `to_sql_type` return `Err` stubs.
+  - `pub fn to_sql_type(...) -> Result<String, DialectError> { Err(DialectError { message: "not implemented".into() }) }`
+  - Add `pub mod dialect;` to `src/util/mod.rs`.
+  - Write inline tests (`mod test { #![allow(unused_imports)] use super::*; ... }`) — see Task 3 for the full test matrix. Tests must fail.
+- **Validate**: `cargo build` succeeds; `cargo test dialect` reports failures (not panics).
+
+### Task 3: Implement `from_str` + full mapping table
+- **Action**: Drive the implementation off the failing tests. Group tests by dialect — one test function per `(dialect, type-class)` clump rather than 24×5 individual tests, to keep the file readable:
+
+  | Test name | Asserts |
+  |---|---|
+  | `from_str_round_trips_all_dialects` | `Dialect::from_str("postgres").unwrap().as_str() == "postgres"` for all 5 dialects |
+  | `from_str_rejects_unknown_target` | `Dialect::from_str("redshift").is_err()`; error message contains `"unsupported target 'redshift'"` and lists the 5 supported names (matches PRD §7) |
+  | `from_str_is_case_insensitive` | `Dialect::from_str("MySQL")` and `Dialect::from_str("MYSQL")` both succeed (defensive — `--target` CLI input is user-typed) |
+  | `int_inc_pk_maps_per_dialect` | `to_sql_type("INT_INC", Mysql, true) == "INT AUTO_INCREMENT PRIMARY KEY"`, plus Postgres → `"SERIAL PRIMARY KEY"`, SQL Server → `"INT IDENTITY(1,1) PRIMARY KEY"`, BigQuery → contains `INT64`, Spark → contains `INT` |
+  | `int_inc_non_pk_drops_identity` | `to_sql_type("INT_INC", Mysql, false) == "INT NOT NULL"`, etc. |
+  | `numeric_types_map_per_dialect` | Covers `INT`, `INT_RNG`, `DECIMAL`, `PRICE`, `LAT`, `LON` across all 5 dialects |
+  | `string_types_map_per_dialect` | Covers `STRING`, `VALUE`, `DIGIT`, `NAME`, `FIRST_NAME`, `LAST_NAME`, `SSN`, `ZIP_CODE`, `COUNTRY_CODE`, `STATE_NAME`, `STATE_ABBR`, `PHONE`, `LOREM_WORD`, `LOREM_TITLE`, `LOREM_SENTENCE`, `LOREM_PARAGRAPH`, `UUID` |
+  | `date_time_types_map_per_dialect` | Covers `DATE`, `TIME`, `DATE_TIME` — including Spark's `TIME → STRING` exception |
+  | `unknown_type_returns_error` | `to_sql_type("FOO", Postgres, false)` returns error matching `"type 'FOO' has no 'postgres' mapping"` |
+  | `is_pk_ignored_for_non_int_inc` | `to_sql_type("STRING", Postgres, true) == to_sql_type("STRING", Postgres, false)` — explicit invariant assertion |
+
+- Implementation shape:
+  ```rust
+  pub fn to_sql_type(gencsv_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError> {
+      let mapped = match (dialect, gencsv_type) {
+          (Dialect::Mysql,    "INT_INC") if is_pk => "INT AUTO_INCREMENT PRIMARY KEY",
+          (Dialect::Mysql,    "INT_INC")           => "INT NOT NULL",
+          (Dialect::Postgres, "INT_INC") if is_pk => "SERIAL PRIMARY KEY",
+          (Dialect::Postgres, "INT_INC")           => "INTEGER NOT NULL",
+          // ... rest of the matrix
+          (_, unknown) => return Err(DialectError {
+              message: format!("type '{unknown}' has no '{}' mapping; supported mappings: see docs/DIALECTS.md", dialect.as_str()),
+          }),
+      };
+      Ok(mapped.to_string())
+  }
+  ```
+  Tuple-match `(Dialect, &str)` keeps the table flat and greppable — readers can `rg "INT_INC"` and see every dialect's row at once. Resist the urge to introduce a `HashMap<(Dialect, String), String>` — that adds runtime allocation for no readability gain at 24×5 entries.
+
+- **Mirror**: `src/util/fake.rs:60-90` (`match element.datatype.as_str()` style).
+- **Validate**: `cargo test dialect` all green; `cargo clippy --all-targets -- -D warnings` clean.
+
+### Task 4: Edge-case + invariant tests
+- **Action**: Add three more inline tests that lock down behaviour the PRD implies but doesn't spell out:
+  - `every_type_in_readme_has_at_least_one_dialect_mapping` — table-driven test that iterates over a hardcoded `const SUPPORTED_TYPES: &[&str] = &["INT_INC", "INT", ...]` (the 24 rows from PRD §6.2) and asserts `to_sql_type(t, d, false).is_ok()` for every `(t, d)` combo. This is the contract: D1 is "complete table coverage", and this single test enforces it.
+  - `error_messages_quote_the_user_input_verbatim` — `to_sql_type("int", ...)` (lowercase) returns error mentioning `'int'`, not `'INT'`. Prevents silent normalisation that would hide typos.
+  - `dialect_display_is_lowercase` — `Dialect::Mysql.as_str() == "mysql"` etc.; matches `--target mysql` CLI convention from PRD §5.1.
+- **Validate**: `cargo test dialect` — all green.
+
+### Task 5: Quality gates + commit
+- **Action**: Run the full pre-commit suite. Conventional commit: `feat: add Dialect enum and gencsv-type -> SQL-type mapping (D1)`.
+- **Validate**: see Validation block below.
+
+## Validation
+
+```bash
+# Formatting
+cargo fmt --all -- --check
+
+# Lints
+cargo clippy --all-targets -- -D warnings
+
+# Unit tests (no integration tests added in D1)
+cargo test dialect
+
+# Full suite — confirm no regressions elsewhere
+cargo test
+
+# Manual sanity: dialect module exposes the surface D2 will consume
+cargo doc --no-deps --open    # optional; verify pub items are documented
+```
+
+Coverage gate (`cargo llvm-cov --fail-under-lines 80`) is a D6 acceptance criterion in the PRD, not D1 — CLAUDE.md notes the repo has no coverage tooling wired up yet. Skip in D1.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Mapping table row drift between PRD §6.2 and `to_sql_type` implementation | **High** | Single source of truth in `dialect.rs`. When D6 ships `docs/DIALECTS.md`, the doc gets generated from a table-driven test or a const slice — not maintained by hand. For D1, the `every_type_in_readme_has_at_least_one_dialect_mapping` test guarantees coverage. |
+| Type-string mismatch between `gencsv` schema and `to_sql_type` keys (e.g. `"INT"` vs `"int"`) | High | `create_column` in `src/util/fake.rs:60` matches uppercase. `to_sql_type` must take the same uppercase key. Add a doc comment on `to_sql_type` pinning this contract: `/// `gencsv_type` must be one of the uppercase keys accepted by `create_column`.` |
+| `clap::ValueEnum` derive adds a build dependency we didn't intend | Low | Clap derive is already on per CLAUDE.md (`clap = "4.5 derive"`). No new crate. |
+| `Dialect::from_str` collides with `std::str::FromStr` trait impl readers might expect | Low | Implement as inherent method `from_str(s: &str) -> Result<Self, DialectError>` rather than the `FromStr` trait — keeps error type local, avoids `std::str::FromStr::Err` boilerplate. Document in the method's doc-comment. |
+| Future DDL emitter (D2) needs more context than `(type, dialect, is_pk)` (e.g. nullability, FK target, length override) | Medium | D1 keeps the signature minimal. D2 will likely wrap `to_sql_type` rather than change it — pass a `ColumnSpec` struct in D2 if needed. Don't pre-design that struct in D1. |
+| Mapping table makes `dialect.rs` >800 lines | Low | 24 types × 5 dialects = 120 match arms — comfortably under the 800-line target from global rules. If it bloats, split into one `fn map_<dialect>(t, is_pk)` per dialect and dispatch from `to_sql_type`. |
+
+## Acceptance
+
+- [ ] `feature/db-targets-d1` branch cut fresh from `main`
+- [ ] `src/util/dialect.rs` exists with `pub enum Dialect`, `pub fn to_sql_type`, `pub struct DialectError`
+- [ ] All 24 rows of PRD §6.2 mapping table are covered (enforced by `every_type_in_readme_has_at_least_one_dialect_mapping` test)
+- [ ] `Dialect::from_str("redshift")` returns the exact error string from PRD §7
+- [ ] `to_sql_type("FOO", ...)` returns the exact error string from PRD §7 (with `docs/DIALECTS.md` reference, even though that doc lands in D6)
+- [ ] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green
+- [ ] No new crate added to `Cargo.toml`
+- [ ] Existing flat-table mode behaviour is unchanged (no files touched outside `src/util/dialect.rs` + `src/util/mod.rs`)
+- [ ] D1 row in PRD §9 marked `in-progress` with link to this plan
+
+## Out of Scope (deferred to later milestones)
+
+- `--target <dialect>` CLI flag → **D2** (needs `DdlEmitter` to make the flag meaningful)
+- `DdlEmitter` (writes `<table>.ddl.<dialect>.sql`) → **D2**
+- `LoadCmdEmitter` (writes `<table>.load.<dialect>.{sql,sh,py}`) → **D3**
+- Parquet logical-type alignment for BigQuery / Spark → **D4**
+- ER-mode integration (per-entity DDL + FK constraints) → **D5** (requires ER PRD M1–M5 complete)
+- `docs/DIALECTS.md` + README quickstart → **D6**
+- `--no-ddl`, `--no-load`, `--no-data` flags + behaviour matrix → **D2/D3**
+- Identifier quoting per dialect (backticks vs double-quotes) → **D2** (only matters at DDL emission)
+- Reserved-word collision handling → **D2**
+
+## Sequencing Note
+
+This milestone is **independent of the ER PRD**. D1 lands a pure-library lookup table; nothing in `feature/erd-v2` (ER M1) reads from `src/util/dialect.rs` or vice-versa. The two branches can be developed and merged in either order without conflict. The PRD-level "Sequenced after ER PRD's M1–M5" sequencing constraint **only binds D5**, which is the milestone that actually plugs into the ER pipeline. D1–D4 may be worked in parallel with the ER track.

--- a/.claude/prds/db-target-types.prd.md
+++ b/.claude/prds/db-target-types.prd.md
@@ -1,0 +1,301 @@
+# PRD: Database-Target Type Definitions
+
+**Status:** Draft
+**Owner:** jheryer
+**Created:** 2026-05-25
+**Target branch:** `feature/db-targets` (fresh from `main`, after ER PRD lands)
+**Depends on:** [`er-diagram-generator.prd.md`](./er-diagram-generator.prd.md) for milestone D5 (ER-mode DDL emission)
+
+---
+
+## 1. Problem
+
+`gencsv` produces CSV (typeless) and Parquet (typed, but generically). Users importing into MySQL, Postgres, SQL Server, BigQuery, or Spark have to:
+
+1. Hand-write a `CREATE TABLE` matching the generated columns
+2. Remember the right `LOAD DATA` / `\copy` / `BULK INSERT` / `bq load` / Spark DataFrame incantation
+3. Hope that Parquet logical types align with the target database's expectations
+
+This friction defeats the "generate fixture data fast" promise of the tool.
+
+## 2. Goal
+
+When the user passes `--target <dialect>`, `gencsv` emits everything needed to land the data in that database:
+
+1. Dialect-correct **Parquet logical types** (when output format is parquet)
+2. A **`CREATE TABLE` DDL file** matching the generated columns
+3. An **example load command** for the target dialect
+4. All of the above composing cleanly with both flat-table mode (`gencsv -s …`) and ER mode (`gencsv er …`)
+
+## 3. Non-Goals
+
+- Direct DB connection / pushing rows (use the generated load command)
+- Per-column DB-type overrides in the schema string (Phase 2)
+- Bounded numeric variants (`TINYINT`, `SMALLINT`, `BIGINT` ranges) (Phase 2)
+- Schema migrations / `ALTER TABLE` emission
+- Dialect-specific generators (e.g. Postgres-flavored JSON column values)
+- Composite primary keys (matches ER PRD scope)
+
+## 4. User Stories
+
+| As a… | I want to… | So that… |
+|---|---|---|
+| Backend engineer | Run `gencsv -s "id:INT_INC,email:STRING" -r 5000 -c -f users.csv --target postgres` and get `users.csv` + `users.ddl.postgres.sql` + `users.load.postgres.sql` | I can `psql -f users.ddl.postgres.sql && psql -f users.load.postgres.sql` and be done |
+| Data engineer | Pipe an ER diagram + `--target bigquery` and get one Parquet per entity plus dialect-correct DDL | I can `bq load --source_format=PARQUET` each table directly |
+| QA engineer | See FK constraints in the emitted DDL for ER-mode output | Loading the data exercises the same referential integrity my production schema does |
+| Anyone | See a clear error if I ask for a target/type combo we don't support | I'm not chasing silent type coercions at load time |
+
+## 5. Functional Requirements
+
+### 5.1 CLI
+
+Existing commands grow three new flags:
+
+```
+gencsv [existing flags...]
+    [--target mysql|postgres|sqlserver|bigquery|spark]
+    [--no-ddl]                  # suppress DDL emission when --target is set
+    [--no-load]                 # suppress load-command emission when --target is set
+    [--no-data]                 # emit only DDL + load command, skip data files (handy for inspection)
+```
+
+Same flags work on `gencsv er <FILE> --target postgres --out DIR`.
+
+### 5.2 Output bundle (one entity, target = `postgres`)
+
+```
+users.csv                       # existing data file
+users.ddl.postgres.sql          # CREATE TABLE
+users.load.postgres.sql         # \copy users FROM 'users.csv' ...
+```
+
+For BigQuery and Spark the load file is a code snippet, not SQL:
+
+```
+users.load.bigquery.sh          # bq load --source_format=PARQUET ...
+users.load.spark.py             # spark.read.parquet(...).write.saveAsTable(...)
+```
+
+### 5.3 Behavior matrix
+
+| `--target` set | `--no-ddl` | `--no-load` | `--no-data` | Result |
+|---|---|---|---|---|
+| no | — | — | — | Current behavior unchanged |
+| yes | no | no | no | Data + DDL + load command (default) |
+| yes | yes | no | no | Data + load command |
+| yes | no | yes | no | Data + DDL |
+| yes | yes | yes | no | Data only (no point — warn the user) |
+| yes | no | no | yes | DDL + load command, no data file |
+
+### 5.4 Parquet logical types
+
+When `--parquet` and `--target` are both set, the Parquet writer uses dialect-aligned logical types:
+
+- BigQuery target → `INT64`, `NUMERIC`, `TIMESTAMP_MICROS`, `STRING`
+- Spark target → `INT32`/`INT64`, `DECIMAL(p,s)`, `TIMESTAMP_MICROS`, `STRING`
+- MySQL / Postgres / SQL Server → physical-type defaults (these dialects rely on the DDL-defined column type rather than Parquet logical types during CSV load; Parquet load paths are non-native for these three)
+
+Caveats per dialect documented in `docs/DIALECTS.md`.
+
+---
+
+## 6. Supported Targets and Type Mappings
+
+### 6.1 Targets in scope
+
+| Dialect ID | Display name | Native load formats |
+|---|---|---|
+| `mysql` | MySQL 8+ | CSV (`LOAD DATA INFILE`) |
+| `postgres` | PostgreSQL 14+ | CSV (`\copy`, `COPY`) |
+| `sqlserver` | SQL Server 2019+ | CSV (`BULK INSERT`) |
+| `bigquery` | Google BigQuery | Parquet (preferred), CSV |
+| `spark` | Apache Spark 3+ | Parquet (preferred), CSV |
+
+### 6.2 Type mapping table (canonical reference)
+
+| gencsv type | MySQL | Postgres | SQL Server | BigQuery | Spark |
+|---|---|---|---|---|---|
+| `INT_INC` (PK) | `INT AUTO_INCREMENT PRIMARY KEY` | `SERIAL PRIMARY KEY` | `INT IDENTITY(1,1) PRIMARY KEY` | `INT64` + comment "// auto-increment not native" | `INT` + comment "// auto-increment not native" |
+| `INT_INC` (non-PK) | `INT NOT NULL` | `INTEGER NOT NULL` | `INT NOT NULL` | `INT64` | `INT` |
+| `INT` | `INT` | `INTEGER` | `INT` | `INT64` | `INT` |
+| `INT_RNG` | `INT` | `INTEGER` | `INT` | `INT64` | `INT` |
+| `DIGIT` | `CHAR(1)` | `CHAR(1)` | `CHAR(1)` | `STRING` | `STRING` |
+| `DECIMAL` | `DECIMAL(10,2)` | `NUMERIC(10,2)` | `DECIMAL(10,2)` | `NUMERIC` | `DECIMAL(10,2)` |
+| `PRICE` | `DECIMAL(10,2)` | `NUMERIC(10,2)` | `MONEY` | `NUMERIC` | `DECIMAL(10,2)` |
+| `STRING` | `VARCHAR(255)` | `TEXT` | `NVARCHAR(255)` | `STRING` | `STRING` |
+| `VALUE` | `VARCHAR(50)` | `VARCHAR(50)` | `VARCHAR(50)` | `STRING` | `STRING` |
+| `DATE` | `DATE` | `DATE` | `DATE` | `DATE` | `DATE` |
+| `TIME` | `TIME` | `TIME` | `TIME` | `TIME` | `STRING` (Spark has no TIME type) |
+| `DATE_TIME` | `DATETIME` | `TIMESTAMP` | `DATETIME2` | `TIMESTAMP` | `TIMESTAMP` |
+| `NAME` / `FIRST_NAME` / `LAST_NAME` | `VARCHAR(100)` | `TEXT` | `NVARCHAR(100)` | `STRING` | `STRING` |
+| `SSN` | `CHAR(11)` | `CHAR(11)` | `CHAR(11)` | `STRING` | `STRING` |
+| `ZIP_CODE` | `VARCHAR(10)` | `VARCHAR(10)` | `VARCHAR(10)` | `STRING` | `STRING` |
+| `COUNTRY_CODE` | `CHAR(2)` | `CHAR(2)` | `CHAR(2)` | `STRING` | `STRING` |
+| `STATE_NAME` | `VARCHAR(64)` | `VARCHAR(64)` | `NVARCHAR(64)` | `STRING` | `STRING` |
+| `STATE_ABBR` | `CHAR(2)` | `CHAR(2)` | `CHAR(2)` | `STRING` | `STRING` |
+| `LAT` / `LON` | `DECIMAL(9,6)` | `NUMERIC(9,6)` | `DECIMAL(9,6)` | `NUMERIC` | `DECIMAL(9,6)` |
+| `PHONE` | `VARCHAR(20)` | `VARCHAR(20)` | `VARCHAR(20)` | `STRING` | `STRING` |
+| `LOREM_WORD` | `VARCHAR(50)` | `VARCHAR(50)` | `NVARCHAR(50)` | `STRING` | `STRING` |
+| `LOREM_TITLE` | `VARCHAR(200)` | `VARCHAR(200)` | `NVARCHAR(200)` | `STRING` | `STRING` |
+| `LOREM_SENTENCE` | `TEXT` | `TEXT` | `NVARCHAR(MAX)` | `STRING` | `STRING` |
+| `LOREM_PARAGRAPH` | `TEXT` | `TEXT` | `NVARCHAR(MAX)` | `STRING` | `STRING` |
+| `UUID` | `CHAR(36)` | `UUID` | `UNIQUEIDENTIFIER` | `STRING` | `STRING` |
+
+### 6.3 Load command templates
+
+| Target | Load template |
+|---|---|
+| `mysql` | `LOAD DATA LOCAL INFILE '{file}' INTO TABLE {table} FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n' IGNORE 1 ROWS;` |
+| `postgres` | `\copy {table} FROM '{file}' WITH (FORMAT csv, HEADER true);` |
+| `sqlserver` | `BULK INSERT {table} FROM '{file}' WITH (FORMAT = 'CSV', FIRSTROW = 2, KEEPIDENTITY);` |
+| `bigquery` (CSV) | `bq load --source_format=CSV --skip_leading_rows=1 {dataset}.{table} {file}` |
+| `bigquery` (Parquet) | `bq load --source_format=PARQUET {dataset}.{table} {file}` |
+| `spark` (CSV) | `spark.read.option("header", True).csv("{file}").write.saveAsTable("{table}")` |
+| `spark` (Parquet) | `spark.read.parquet("{file}").write.saveAsTable("{table}")` |
+
+Template placeholders `{file}`, `{table}`, `{dataset}` are filled at emit time. `{dataset}` for BigQuery defaults to `dataset` with a generated comment telling the user to substitute their own.
+
+### 6.4 ER-mode DDL emission (D5)
+
+For ER input, DDL emission additionally produces:
+
+1. One `CREATE TABLE` per entity (including the auto-generated junction tables)
+2. `FOREIGN KEY (<fk_col>) REFERENCES <parent>(<parent_pk>)` constraints
+3. Tables emitted in topological order so the DDL file is replayable top-to-bottom
+
+---
+
+## 7. Rejected Inputs (with required error messages)
+
+| Input | Why rejected | Required error |
+|---|---|---|
+| `--target redshift` (or any unsupported dialect) | Out of scope | `unsupported target 'redshift'; supported: mysql, postgres, sqlserver, bigquery, spark` |
+| `--no-data --no-ddl --no-load` together | Nothing to do | `--no-data --no-ddl --no-load: nothing to emit` |
+| `--target X` without `--file-target` | Need a path to write companion files | `--target requires --file-target so DDL and load files can be placed next to data` |
+| Type with no dialect mapping (future custom types) | Mapping table miss | `type 'foo' has no '{dialect}' mapping; supported mappings: see docs/DIALECTS.md` |
+| `--target spark` + `--csv` + relying on auto-load | Spark loads better from Parquet | Warning (not error): `target spark prefers Parquet; consider --parquet` |
+
+All errors exit non-zero and produce no partial output.
+
+---
+
+## 8. Architecture
+
+```
+                          ┌──────────────────────────────────┐
+                          │ Args: --target --no-ddl ...      │
+                          └────────────┬─────────────────────┘
+                                       v
+┌────────────────┐    ┌────────────────────────────────┐
+│ Schema parser  │ -> │ TypeResolver (gencsv types)    │
+└────────────────┘    └────────────────┬───────────────┘
+                                       │
+                          ┌────────────┴────────────┐
+                          v                         v
+                 ┌──────────────────┐    ┌──────────────────────┐
+                 │ DataFrame build  │    │ Dialect mapper       │
+                 │ (existing)       │    │ src/util/dialect.rs  │
+                 └────────┬─────────┘    └──────────┬───────────┘
+                          │                         │
+                          v                         v
+                 ┌────────────────┐      ┌──────────────────────┐
+                 │ MultiSink      │      │ DdlEmitter           │
+                 │ + ParquetType  │ <-── │ LoadCmdEmitter       │
+                 │ overrides      │      │ src/util/ddl.rs      │
+                 └────────────────┘      │ src/util/load_cmd.rs │
+                          │              └──────────────────────┘
+                          v                         │
+                  data.{csv,parquet}                v
+                                          data.ddl.<dialect>.sql
+                                          data.load.<dialect>.{sql,sh,py}
+```
+
+### Files to create / change
+
+| File | Action | Why |
+|---|---|---|
+| `src/util/dialect.rs` | CREATE | `Dialect` enum + `to_sql_type(gencsv_type, is_pk) -> &str` per dialect; load template lookup |
+| `src/util/ddl.rs` | CREATE | `emit_create_table(table_name, columns, dialect) -> String`; FK constraint support |
+| `src/util/load_cmd.rs` | CREATE | Template renderer per dialect; choose file extension |
+| `src/util/output.rs` | UPDATE | Add `DdlFile`, `LoadCmdFile` sinks; teach `ParquetFile::new_for_dialect` |
+| `src/util/schema.rs` | UPDATE | Add optional `is_pk: bool` on `Schema` (defaults to false; back-compat) |
+| `src/main.rs` | UPDATE | New `--target`, `--no-ddl`, `--no-load`, `--no-data` clap args |
+| `src/lib.rs` | UPDATE | Route `--target` through `run()`; orchestrate companion-file emission |
+| `tests/fixtures/dialects/*.expected.sql` | CREATE | Golden DDL per (table × dialect) |
+| `tests/cli.rs` | UPDATE | One round-trip integration test per dialect |
+| `docs/DIALECTS.md` | CREATE | Full type-mapping reference + per-dialect caveats |
+| `README.md` | UPDATE | Quickstart with `--target postgres` example |
+
+### Patterns to mirror
+
+| Category | Source | Pattern |
+|---|---|---|
+| Errors | `src/util/dataframe.rs:21` | `Box<dyn Error>` with `format!("...: {e}")` context |
+| Sink trait | `src/util/output.rs:7` | New emitters implement `Output` so they slot into `run()` uniformly |
+| Type dispatch | `src/util/fake.rs:60` | `match dialect { Mysql => ... }` per type, no dyn dispatch |
+| Tests | `src/util/fake.rs:270` | Co-located `#[cfg(test)] mod test` with golden-string assertions |
+| Integration | `tests/cli.rs` | `assert_cmd` + file existence + content snapshot |
+
+---
+
+## 9. Delivery Milestones
+
+| # | Milestone | Plan | Status |
+|---|---|---|---|
+| D1 | `Dialect` enum + complete type-mapping table + unit tests (no I/O) | [.claude/plans/db-target-types-d1.plan.md](../plans/db-target-types-d1.plan.md) | in-progress |
+| D2 | `DdlEmitter` writes `<table>.ddl.<dialect>.sql` for flat-table mode + per-dialect golden tests | _pending_ | pending |
+| D3 | `LoadCmdEmitter` writes `<table>.load.<dialect>.{sql,sh,py}` + per-dialect golden tests | _pending_ | pending |
+| D4 | Parquet logical-type alignment per dialect (BigQuery, Spark) | _pending_ | pending |
+| D5 | ER-mode integration: emit one DDL per entity + FK constraints; junction tables get DDL too (depends on ER PRD M5) | _pending_ | pending |
+| D6 | `docs/DIALECTS.md` + README update + ≥80% coverage maintained | _pending_ | pending |
+
+Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and lands as its own PR. **Sequenced after the ER PRD's M1–M5 complete** so D5 has a real ER pipeline to plug into.
+
+---
+
+## 10. Acceptance Criteria
+
+- [ ] `gencsv -s "id:INT_INC,email:STRING" -r 100 -c -f users.csv --target postgres` produces `users.csv`, `users.ddl.postgres.sql`, `users.load.postgres.sql`
+- [ ] Loading the generated bundle into the matching DB succeeds end-to-end for at least Postgres and MySQL (manual smoke test recorded in `docs/DIALECTS.md`)
+- [ ] All five dialects produce DDL that matches `tests/fixtures/dialects/*.expected.sql`
+- [ ] ER-mode + `--target` emits per-entity DDL with FK constraints in topological replay order
+- [ ] All errors in §7 are reproducible via fixture inputs and produce documented messages
+- [ ] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo llvm-cov --fail-under-lines 80` pass in CI
+- [ ] No regressions in flat-table mode without `--target` (existing tests stay green)
+
+---
+
+## 11. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Generated value ranges exceed target type (`fake_int()` is `i32::MAX`, doesn't fit MySQL `SMALLINT`) | High | Document safe ranges per gencsv type; defer bounded variants to Phase 2 |
+| Polars 0.38 Parquet writer doesn't expose all logical-type knobs | Medium | Use physical-type defaults where logical types aren't reachable; document gaps |
+| SQL Server `IDENTITY` columns reject inserts without `KEEPIDENTITY` | High | Emit `WITH (KEEPIDENTITY)` in the BULK INSERT template; document in DIALECTS.md |
+| BigQuery `bq` CLI requires `{dataset}` placeholder the user must fill in | Medium | Leave as `dataset` with `# TODO: replace` comment; document in DIALECTS.md |
+| Spark "load command" is really Scala/Python, not shell | Low | Choose file extension by dialect (`.sh` for MySQL/Postgres/SQLServer/BigQuery, `.py` for Spark) |
+| Combinatorial test explosion (5 dialects × ~25 types × CSV/Parquet) | Medium | Golden-file tests cover type mapping; one integration round-trip per dialect; trust unit tests for the matrix |
+| Composite FKs differ across dialects | Low | Out of scope in v1 (matches ER PRD); single-column FK syntax is portable |
+| Reserved-word collisions in DDL (e.g. entity named `ORDER`) | Medium | Wrap identifiers in backticks (MySQL), double quotes (Postgres, SQL Server, BigQuery), backticks (Spark) — per-dialect quoter |
+
+---
+
+## 12. Open Questions
+
+- Should the load command file be executable (`chmod +x`) for shell targets? (Default: no — user opts in.)
+- For BigQuery, should we emit a `bq mk` command for the dataset too? (Default: no — out of scope; document the prerequisite.)
+- Should `--target` accept a comma list (`--target mysql,postgres`) to emit bundles for multiple dialects in one run? (Default: no in v1 — single target per invocation; revisit if users ask.)
+- Should `STRING` width default to `255` (current proposal) or `TEXT` everywhere? (Default per table; revisit after first user feedback.)
+
+---
+
+## 13. References
+
+- ER PRD (sibling): [`er-diagram-generator.prd.md`](./er-diagram-generator.prd.md)
+- Current `gencsv` README: `/README.md`
+- Current architecture notes: `/CLAUDE.md`
+- MySQL `LOAD DATA`: https://dev.mysql.com/doc/refman/8.0/en/load-data.html
+- Postgres `COPY`: https://www.postgresql.org/docs/current/sql-copy.html
+- SQL Server `BULK INSERT`: https://learn.microsoft.com/sql/t-sql/statements/bulk-insert-transact-sql
+- BigQuery `bq load`: https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet
+- Spark Parquet: https://spark.apache.org/docs/latest/sql-data-sources-parquet.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ type RunResult<T> = Result<T, Box<dyn Error>>;
 
 // D1: re-export dialect API so D2's `--target` CLI flag and DDL emitter can
 // reach it without poking through `util::`.
-pub use util::dialect::{Dialect, DialectError, to_sql_type};
+pub use util::dialect::{to_sql_type, Dialect, DialectError};
 
 pub fn run(
     schema: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ use util::{dataframe::create_dataframe, output::Console};
 use crate::util::output::{CSVFile, Output, ParquetFile};
 type RunResult<T> = Result<T, Box<dyn Error>>;
 
+// D1: re-export dialect API so D2's `--target` CLI flag and DDL emitter can
+// reach it without poking through `util::`.
+pub use util::dialect::{Dialect, DialectError, to_sql_type};
+
 pub fn run(
     schema: Option<String>,
     rows: usize,

--- a/src/util/dialect.rs
+++ b/src/util/dialect.rs
@@ -1,0 +1,548 @@
+//! Database-target dialect support (D1 of `.claude/prds/db-target-types.prd.md`).
+//!
+//! This module exposes:
+//! - `Dialect`: the set of supported target databases
+//! - `to_sql_type`: mapping from a gencsv schema type (uppercase keys matching
+//!   `src/util/fake.rs::create_column`) to a dialect-specific SQL column type
+//!   string per PRD §6.2.
+//!
+//! D1 is the lookup table only. DDL string assembly, load commands, Parquet
+//! logical-type wiring, and the `--target` CLI flag land in D2+.
+
+use clap::ValueEnum;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Dialect {
+    Mysql,
+    Postgres,
+    Sqlserver,
+    Bigquery,
+    Spark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DialectError {
+    pub message: String,
+}
+
+impl fmt::Display for DialectError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for DialectError {}
+
+impl Dialect {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Dialect::Mysql => "mysql",
+            Dialect::Postgres => "postgres",
+            Dialect::Sqlserver => "sqlserver",
+            Dialect::Bigquery => "bigquery",
+            Dialect::Spark => "spark",
+        }
+    }
+
+    /// Parse a `--target` CLI argument. Case-insensitive so users don't need
+    /// to remember exact casing. Inherent method (not `std::str::FromStr`)
+    /// so the error type stays local to this module — the trait's associated
+    /// `Err` type would force a more awkward signature.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Self, DialectError> {
+        match s.to_lowercase().as_str() {
+            "mysql" => Ok(Dialect::Mysql),
+            "postgres" => Ok(Dialect::Postgres),
+            "sqlserver" => Ok(Dialect::Sqlserver),
+            "bigquery" => Ok(Dialect::Bigquery),
+            "spark" => Ok(Dialect::Spark),
+            _ => Err(DialectError {
+                message: format!(
+                    "unsupported target '{s}'; supported: mysql, postgres, sqlserver, bigquery, spark"
+                ),
+            }),
+        }
+    }
+}
+
+/// Map a gencsv schema type to a SQL column-type string for the given dialect.
+///
+/// `gencsv_type` must be one of the uppercase keys accepted by
+/// `src/util/fake.rs::create_column` (e.g. `"INT_INC"`, `"STRING"`,
+/// `"DATE_TIME"`). `is_pk` only changes the result for `"INT_INC"`; for every
+/// other type it is accepted but ignored. PK decoration of non-`INT_INC`
+/// columns is deferred to D2 where the DDL emitter has full column context.
+pub fn to_sql_type(
+    gencsv_type: &str,
+    dialect: Dialect,
+    is_pk: bool,
+) -> Result<String, DialectError> {
+    use Dialect::*;
+    let mapped: &str = match (gencsv_type, dialect) {
+        // INT_INC: only type whose mapping depends on is_pk
+        ("INT_INC", Mysql) if is_pk => "INT AUTO_INCREMENT PRIMARY KEY",
+        ("INT_INC", Postgres) if is_pk => "SERIAL PRIMARY KEY",
+        ("INT_INC", Sqlserver) if is_pk => "INT IDENTITY(1,1) PRIMARY KEY",
+        ("INT_INC", Bigquery) if is_pk => "INT64",
+        ("INT_INC", Spark) if is_pk => "INT",
+        ("INT_INC", Mysql) => "INT NOT NULL",
+        ("INT_INC", Postgres) => "INTEGER NOT NULL",
+        ("INT_INC", Sqlserver) => "INT NOT NULL",
+        ("INT_INC", Bigquery) => "INT64",
+        ("INT_INC", Spark) => "INT",
+
+        // INT, INT_RNG: plain integers
+        ("INT", Mysql) | ("INT_RNG", Mysql) => "INT",
+        ("INT", Postgres) | ("INT_RNG", Postgres) => "INTEGER",
+        ("INT", Sqlserver) | ("INT_RNG", Sqlserver) => "INT",
+        ("INT", Bigquery) | ("INT_RNG", Bigquery) => "INT64",
+        ("INT", Spark) | ("INT_RNG", Spark) => "INT",
+
+        // DIGIT: single character
+        ("DIGIT", Mysql) | ("DIGIT", Postgres) | ("DIGIT", Sqlserver) => "CHAR(1)",
+        ("DIGIT", Bigquery) | ("DIGIT", Spark) => "STRING",
+
+        // DECIMAL
+        ("DECIMAL", Mysql) => "DECIMAL(10,2)",
+        ("DECIMAL", Postgres) => "NUMERIC(10,2)",
+        ("DECIMAL", Sqlserver) => "DECIMAL(10,2)",
+        ("DECIMAL", Bigquery) => "NUMERIC",
+        ("DECIMAL", Spark) => "DECIMAL(10,2)",
+
+        // PRICE: SQL Server gets MONEY
+        ("PRICE", Mysql) => "DECIMAL(10,2)",
+        ("PRICE", Postgres) => "NUMERIC(10,2)",
+        ("PRICE", Sqlserver) => "MONEY",
+        ("PRICE", Bigquery) => "NUMERIC",
+        ("PRICE", Spark) => "DECIMAL(10,2)",
+
+        // STRING: longest variable text
+        ("STRING", Mysql) => "VARCHAR(255)",
+        ("STRING", Postgres) => "TEXT",
+        ("STRING", Sqlserver) => "NVARCHAR(255)",
+        ("STRING", Bigquery) | ("STRING", Spark) => "STRING",
+
+        // VALUE: short fixed-purpose literal
+        ("VALUE", Mysql) | ("VALUE", Postgres) | ("VALUE", Sqlserver) => "VARCHAR(50)",
+        ("VALUE", Bigquery) | ("VALUE", Spark) => "STRING",
+
+        // DATE / TIME / DATE_TIME
+        ("DATE", Mysql) | ("DATE", Postgres) | ("DATE", Sqlserver) => "DATE",
+        ("DATE", Bigquery) | ("DATE", Spark) => "DATE",
+
+        ("TIME", Mysql) | ("TIME", Postgres) | ("TIME", Sqlserver) => "TIME",
+        ("TIME", Bigquery) => "TIME",
+        ("TIME", Spark) => "STRING", // Spark has no TIME type
+
+        ("DATE_TIME", Mysql) => "DATETIME",
+        ("DATE_TIME", Postgres) => "TIMESTAMP",
+        ("DATE_TIME", Sqlserver) => "DATETIME2",
+        ("DATE_TIME", Bigquery) | ("DATE_TIME", Spark) => "TIMESTAMP",
+
+        // Name family
+        ("NAME", Mysql) | ("FIRST_NAME", Mysql) | ("LAST_NAME", Mysql) => "VARCHAR(100)",
+        ("NAME", Postgres) | ("FIRST_NAME", Postgres) | ("LAST_NAME", Postgres) => "TEXT",
+        ("NAME", Sqlserver) | ("FIRST_NAME", Sqlserver) | ("LAST_NAME", Sqlserver) => {
+            "NVARCHAR(100)"
+        }
+        ("NAME", Bigquery)
+        | ("FIRST_NAME", Bigquery)
+        | ("LAST_NAME", Bigquery)
+        | ("NAME", Spark)
+        | ("FIRST_NAME", Spark)
+        | ("LAST_NAME", Spark) => "STRING",
+
+        // SSN
+        ("SSN", Mysql) | ("SSN", Postgres) | ("SSN", Sqlserver) => "CHAR(11)",
+        ("SSN", Bigquery) | ("SSN", Spark) => "STRING",
+
+        // ZIP_CODE
+        ("ZIP_CODE", Mysql) | ("ZIP_CODE", Postgres) | ("ZIP_CODE", Sqlserver) => "VARCHAR(10)",
+        ("ZIP_CODE", Bigquery) | ("ZIP_CODE", Spark) => "STRING",
+
+        // COUNTRY_CODE
+        ("COUNTRY_CODE", Mysql) | ("COUNTRY_CODE", Postgres) | ("COUNTRY_CODE", Sqlserver) => {
+            "CHAR(2)"
+        }
+        ("COUNTRY_CODE", Bigquery) | ("COUNTRY_CODE", Spark) => "STRING",
+
+        // STATE_NAME
+        ("STATE_NAME", Mysql) | ("STATE_NAME", Postgres) => "VARCHAR(64)",
+        ("STATE_NAME", Sqlserver) => "NVARCHAR(64)",
+        ("STATE_NAME", Bigquery) | ("STATE_NAME", Spark) => "STRING",
+
+        // STATE_ABBR
+        ("STATE_ABBR", Mysql) | ("STATE_ABBR", Postgres) | ("STATE_ABBR", Sqlserver) => "CHAR(2)",
+        ("STATE_ABBR", Bigquery) | ("STATE_ABBR", Spark) => "STRING",
+
+        // LAT / LON
+        ("LAT", Mysql) | ("LON", Mysql) => "DECIMAL(9,6)",
+        ("LAT", Postgres) | ("LON", Postgres) => "NUMERIC(9,6)",
+        ("LAT", Sqlserver) | ("LON", Sqlserver) => "DECIMAL(9,6)",
+        ("LAT", Bigquery) | ("LON", Bigquery) => "NUMERIC",
+        ("LAT", Spark) | ("LON", Spark) => "DECIMAL(9,6)",
+
+        // PHONE
+        ("PHONE", Mysql) | ("PHONE", Postgres) | ("PHONE", Sqlserver) => "VARCHAR(20)",
+        ("PHONE", Bigquery) | ("PHONE", Spark) => "STRING",
+
+        // LOREM_WORD
+        ("LOREM_WORD", Mysql) | ("LOREM_WORD", Postgres) => "VARCHAR(50)",
+        ("LOREM_WORD", Sqlserver) => "NVARCHAR(50)",
+        ("LOREM_WORD", Bigquery) | ("LOREM_WORD", Spark) => "STRING",
+
+        // LOREM_TITLE
+        ("LOREM_TITLE", Mysql) | ("LOREM_TITLE", Postgres) => "VARCHAR(200)",
+        ("LOREM_TITLE", Sqlserver) => "NVARCHAR(200)",
+        ("LOREM_TITLE", Bigquery) | ("LOREM_TITLE", Spark) => "STRING",
+
+        // LOREM_SENTENCE / LOREM_PARAGRAPH
+        ("LOREM_SENTENCE", Mysql)
+        | ("LOREM_SENTENCE", Postgres)
+        | ("LOREM_PARAGRAPH", Mysql)
+        | ("LOREM_PARAGRAPH", Postgres) => "TEXT",
+        ("LOREM_SENTENCE", Sqlserver) | ("LOREM_PARAGRAPH", Sqlserver) => "NVARCHAR(MAX)",
+        ("LOREM_SENTENCE", Bigquery)
+        | ("LOREM_SENTENCE", Spark)
+        | ("LOREM_PARAGRAPH", Bigquery)
+        | ("LOREM_PARAGRAPH", Spark) => "STRING",
+
+        // UUID
+        ("UUID", Mysql) => "CHAR(36)",
+        ("UUID", Postgres) => "UUID",
+        ("UUID", Sqlserver) => "UNIQUEIDENTIFIER",
+        ("UUID", Bigquery) | ("UUID", Spark) => "STRING",
+
+        (unknown, d) => {
+            return Err(DialectError {
+                message: format!(
+                    "type '{unknown}' has no '{}' mapping; supported mappings: see docs/DIALECTS.md",
+                    d.as_str()
+                ),
+            });
+        }
+    };
+    Ok(mapped.to_string())
+}
+
+mod test {
+    #![allow(unused_imports, dead_code)]
+    use super::*;
+
+    /// Canonical list of every gencsv type covered by D1, drawn from PRD §6.2.
+    /// Used by the contract test in `every_type_has_mapping_for_every_dialect`.
+    const SUPPORTED_TYPES: &[&str] = &[
+        "INT_INC",
+        "INT",
+        "INT_RNG",
+        "DIGIT",
+        "DECIMAL",
+        "PRICE",
+        "STRING",
+        "VALUE",
+        "DATE",
+        "TIME",
+        "DATE_TIME",
+        "NAME",
+        "FIRST_NAME",
+        "LAST_NAME",
+        "SSN",
+        "ZIP_CODE",
+        "COUNTRY_CODE",
+        "STATE_NAME",
+        "STATE_ABBR",
+        "LAT",
+        "LON",
+        "PHONE",
+        "LOREM_WORD",
+        "LOREM_TITLE",
+        "LOREM_SENTENCE",
+        "LOREM_PARAGRAPH",
+        "UUID",
+    ];
+
+    const ALL_DIALECTS: &[Dialect] = &[
+        Dialect::Mysql,
+        Dialect::Postgres,
+        Dialect::Sqlserver,
+        Dialect::Bigquery,
+        Dialect::Spark,
+    ];
+
+    // ---------- from_str / as_str ----------
+
+    #[test]
+    fn from_str_round_trips_all_dialects() {
+        for d in ALL_DIALECTS {
+            let parsed = Dialect::from_str(d.as_str()).unwrap();
+            assert_eq!(parsed, *d);
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_target() {
+        let err = Dialect::from_str("redshift").unwrap_err();
+        assert!(
+            err.message.contains("unsupported target 'redshift'"),
+            "got: {}",
+            err.message
+        );
+        for name in ["mysql", "postgres", "sqlserver", "bigquery", "spark"] {
+            assert!(
+                err.message.contains(name),
+                "missing {name} in supported list: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive() {
+        assert_eq!(Dialect::from_str("MySQL").unwrap(), Dialect::Mysql);
+        assert_eq!(Dialect::from_str("MYSQL").unwrap(), Dialect::Mysql);
+        // 'PostgreSQL' isn't in the supported list — we accept 'postgres' only
+        assert!(Dialect::from_str("PostgreSQL").is_err());
+        assert_eq!(Dialect::from_str("BIGQUERY").unwrap(), Dialect::Bigquery);
+    }
+
+    #[test]
+    fn dialect_display_is_lowercase() {
+        assert_eq!(Dialect::Mysql.as_str(), "mysql");
+        assert_eq!(Dialect::Postgres.as_str(), "postgres");
+        assert_eq!(Dialect::Sqlserver.as_str(), "sqlserver");
+        assert_eq!(Dialect::Bigquery.as_str(), "bigquery");
+        assert_eq!(Dialect::Spark.as_str(), "spark");
+    }
+
+    // ---------- INT_INC (PK-sensitive) ----------
+
+    #[test]
+    fn int_inc_pk_maps_per_dialect() {
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Mysql, true).unwrap(),
+            "INT AUTO_INCREMENT PRIMARY KEY"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Postgres, true).unwrap(),
+            "SERIAL PRIMARY KEY"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Sqlserver, true).unwrap(),
+            "INT IDENTITY(1,1) PRIMARY KEY"
+        );
+        assert!(to_sql_type("INT_INC", Dialect::Bigquery, true)
+            .unwrap()
+            .contains("INT64"));
+        assert!(to_sql_type("INT_INC", Dialect::Spark, true)
+            .unwrap()
+            .contains("INT"));
+    }
+
+    #[test]
+    fn int_inc_non_pk_drops_identity_decoration() {
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Mysql, false).unwrap(),
+            "INT NOT NULL"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Postgres, false).unwrap(),
+            "INTEGER NOT NULL"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Sqlserver, false).unwrap(),
+            "INT NOT NULL"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Bigquery, false).unwrap(),
+            "INT64"
+        );
+        assert_eq!(
+            to_sql_type("INT_INC", Dialect::Spark, false).unwrap(),
+            "INT"
+        );
+    }
+
+    // ---------- Type-class spot checks (PRD §6.2 rows) ----------
+
+    #[test]
+    fn numeric_types_map_per_dialect() {
+        assert_eq!(
+            to_sql_type("INT", Dialect::Postgres, false).unwrap(),
+            "INTEGER"
+        );
+        assert_eq!(
+            to_sql_type("INT_RNG", Dialect::Bigquery, false).unwrap(),
+            "INT64"
+        );
+        assert_eq!(
+            to_sql_type("DECIMAL", Dialect::Postgres, false).unwrap(),
+            "NUMERIC(10,2)"
+        );
+        assert_eq!(
+            to_sql_type("PRICE", Dialect::Sqlserver, false).unwrap(),
+            "MONEY"
+        );
+        assert_eq!(
+            to_sql_type("LAT", Dialect::Mysql, false).unwrap(),
+            "DECIMAL(9,6)"
+        );
+        assert_eq!(
+            to_sql_type("LON", Dialect::Bigquery, false).unwrap(),
+            "NUMERIC"
+        );
+    }
+
+    #[test]
+    fn string_types_map_per_dialect() {
+        assert_eq!(
+            to_sql_type("STRING", Dialect::Mysql, false).unwrap(),
+            "VARCHAR(255)"
+        );
+        assert_eq!(
+            to_sql_type("STRING", Dialect::Postgres, false).unwrap(),
+            "TEXT"
+        );
+        assert_eq!(
+            to_sql_type("STRING", Dialect::Sqlserver, false).unwrap(),
+            "NVARCHAR(255)"
+        );
+        assert_eq!(
+            to_sql_type("STRING", Dialect::Bigquery, false).unwrap(),
+            "STRING"
+        );
+        assert_eq!(
+            to_sql_type("VALUE", Dialect::Mysql, false).unwrap(),
+            "VARCHAR(50)"
+        );
+        assert_eq!(
+            to_sql_type("UUID", Dialect::Postgres, false).unwrap(),
+            "UUID"
+        );
+        assert_eq!(
+            to_sql_type("UUID", Dialect::Sqlserver, false).unwrap(),
+            "UNIQUEIDENTIFIER"
+        );
+        assert_eq!(
+            to_sql_type("UUID", Dialect::Mysql, false).unwrap(),
+            "CHAR(36)"
+        );
+        assert_eq!(
+            to_sql_type("SSN", Dialect::Mysql, false).unwrap(),
+            "CHAR(11)"
+        );
+        assert_eq!(
+            to_sql_type("COUNTRY_CODE", Dialect::Postgres, false).unwrap(),
+            "CHAR(2)"
+        );
+        assert_eq!(
+            to_sql_type("LOREM_PARAGRAPH", Dialect::Sqlserver, false).unwrap(),
+            "NVARCHAR(MAX)"
+        );
+        assert_eq!(
+            to_sql_type("NAME", Dialect::Sqlserver, false).unwrap(),
+            "NVARCHAR(100)"
+        );
+    }
+
+    #[test]
+    fn date_time_types_map_per_dialect() {
+        assert_eq!(to_sql_type("DATE", Dialect::Mysql, false).unwrap(), "DATE");
+        assert_eq!(
+            to_sql_type("TIME", Dialect::Postgres, false).unwrap(),
+            "TIME"
+        );
+        // Spark has no TIME type — must fall back to STRING per PRD §6.2
+        assert_eq!(
+            to_sql_type("TIME", Dialect::Spark, false).unwrap(),
+            "STRING"
+        );
+        assert_eq!(
+            to_sql_type("DATE_TIME", Dialect::Mysql, false).unwrap(),
+            "DATETIME"
+        );
+        assert_eq!(
+            to_sql_type("DATE_TIME", Dialect::Postgres, false).unwrap(),
+            "TIMESTAMP"
+        );
+        assert_eq!(
+            to_sql_type("DATE_TIME", Dialect::Sqlserver, false).unwrap(),
+            "DATETIME2"
+        );
+    }
+
+    // ---------- Error paths ----------
+
+    #[test]
+    fn unknown_type_returns_error_with_dialect_name() {
+        let err = to_sql_type("FOO", Dialect::Postgres, false).unwrap_err();
+        assert!(err.message.contains("type 'FOO'"), "got: {}", err.message);
+        assert!(err.message.contains("'postgres'"), "got: {}", err.message);
+        assert!(
+            err.message.contains("docs/DIALECTS.md"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn error_messages_quote_user_input_verbatim() {
+        // Lowercase 'int' is not a recognized key — must NOT be silently
+        // normalised to 'INT'. The error must echo what the user typed so
+        // typos are easy to spot.
+        let err = to_sql_type("int", Dialect::Postgres, false).unwrap_err();
+        assert!(
+            err.message.contains("'int'"),
+            "expected verbatim 'int' in error: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("'INT'"),
+            "must not silently normalise to 'INT': {}",
+            err.message
+        );
+    }
+
+    // ---------- Contract invariants ----------
+
+    #[test]
+    fn is_pk_is_ignored_for_non_int_inc_types() {
+        for d in ALL_DIALECTS {
+            for t in SUPPORTED_TYPES {
+                if *t == "INT_INC" {
+                    continue;
+                }
+                let with_pk = to_sql_type(t, *d, true).unwrap();
+                let without_pk = to_sql_type(t, *d, false).unwrap();
+                assert_eq!(
+                    with_pk, without_pk,
+                    "is_pk changed mapping for ({t}, {:?})",
+                    d
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_type_has_mapping_for_every_dialect() {
+        // The D1 contract: full coverage of PRD §6.2. If a type is added in
+        // PRD §6.2, it MUST get a row in to_sql_type before this test passes.
+        for d in ALL_DIALECTS {
+            for t in SUPPORTED_TYPES {
+                let result = to_sql_type(t, *d, false);
+                assert!(
+                    result.is_ok(),
+                    "missing mapping for ({t}, {:?}): {:?}",
+                    d,
+                    result.err()
+                );
+                assert!(
+                    !result.as_ref().unwrap().is_empty(),
+                    "empty mapping for ({t}, {:?})",
+                    d
+                );
+            }
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod dataframe;
+pub mod dialect;
 pub mod fake;
 pub mod output;
 pub mod schema;


### PR DESCRIPTION
## Summary

Lands milestone **D1** from [`.claude/prds/db-target-types.prd.md`](https://github.com/jheryer/gencsvrs/blob/feature/db-targets-d1/.claude/prds/db-target-types.prd.md): the pure-library foundation for DDL emission (D2), load-command rendering (D3), Parquet logical-type alignment (D4), and ER-mode DDL integration (D5).

Independent of the ER PRD work — D1–D4 have no behavioural overlap with ER. Only D5 plugs into the ER pipeline.

## Changes

- **`src/util/dialect.rs`**
  - \`Dialect\` enum (\`Mysql\`, \`Postgres\`, \`Sqlserver\`, \`Bigquery\`, \`Spark\`) with \`clap::ValueEnum\` derive so the future \`--target\` flag is zero-refactor.
  - Inherent \`from_str\` (case-insensitive) keeps \`DialectError\` local instead of being forced through \`std::str::FromStr\`'s associated-type boilerplate.
  - \`to_sql_type(gencsv_type, dialect, is_pk)\` — tuple-match over the full **27-type × 5-dialect** matrix from PRD §6.2. \`is_pk\` only changes the result for \`INT_INC\` (the only auto-increment-decorated row); a contract test enforces the invariant.
  - Unknown types return the exact PRD §7 error string with \`docs/DIALECTS.md\` reference (the doc lands in D6 — error string is pre-baked so we don't have to update it later).
- **`src/lib.rs`** — \`pub use util::dialect::{Dialect, DialectError, to_sql_type}\` so D2 consumers reach the dialect API without poking through \`util::\`. No changes to existing flat-table mode.
- **`src/util/mod.rs`** — declare the new submodule.
- **`.claude/prds/db-target-types.prd.md`** — added (was untracked); D1 row flipped to \`in-progress\` with plan link.
- **`.claude/plans/db-target-types-d1.plan.md`** — the plan this PR executes.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean (with one documented \`#[allow(clippy::should_implement_trait)]\` on inherent \`from_str\`)
- [x] \`cargo test\` — 55 lib tests + 7 integration tests, all green
- [x] **13 new unit tests**, including two contract invariants:
  - \`every_type_has_mapping_for_every_dialect\` — full §6.2 coverage gate; will fail if a type is added to the PRD without a matching arm in \`to_sql_type\`
  - \`is_pk_is_ignored_for_non_int_inc_types\` — explicit invariant assertion
  - \`error_messages_quote_user_input_verbatim\` — prevents silent normalisation that would hide typos
- [x] No new crates added (\`clap::ValueEnum\` derive uses existing dependency)
- [x] Zero changes to existing flat-table mode

## Follow-ups

- **D2**: \`--target\` CLI flag + \`DdlEmitter\` (writes \`<table>.ddl.<dialect>.sql\`)
- **D3**: \`LoadCmdEmitter\` (writes \`<table>.load.<dialect>.{sql,sh,py}\`)
- **D4**: Parquet logical-type alignment for BigQuery / Spark
- **D5**: ER-mode integration (per-entity DDL + FK constraints) — depends on ER PRD M1–M5
- **D6**: \`docs/DIALECTS.md\` + README quickstart