### PR TITLE
feat: DDL emitter + --target flag (D2)

### DIFF
--- a/.claude/prds/db-target-types.prd.md
+++ b/.claude/prds/db-target-types.prd.md
@@ -242,7 +242,7 @@ All errors exit non-zero and produce no partial output.
 
 | # | Milestone | Plan | Status |
 |---|---|---|---|
-| D1 | `Dialect` enum + complete type-mapping table + unit tests (no I/O) | [.claude/plans/db-target-types-d1.plan.md](../plans/db-target-types-d1.plan.md) | in-progress |
+| D1 | `Dialect` enum + complete type-mapping table + unit tests (no I/O) | [.claude/plans/db-target-types-d1.plan.md](../plans/db-target-types-d1.plan.md) | done |
 | D2 | `DdlEmitter` writes `<table>.ddl.<dialect>.sql` for flat-table mode + per-dialect golden tests | _pending_ | pending |
 | D3 | `LoadCmdEmitter` writes `<table>.load.<dialect>.{sql,sh,py}` + per-dialect golden tests | _pending_ | pending |
 | D4 | Parquet logical-type alignment per dialect (BigQuery, Spark) | _pending_ | pending |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use util::schema::{default_schema, parse_schema};
 use util::{dataframe::create_dataframe, output::Console};
 
+use crate::util::ddl::{ddl_path, emit_create_table, table_name_from_path};
 use crate::util::generator::generate;
 use crate::util::multi_file_sink::{MultiFileSink, SinkFormat};
 use crate::util::output::{CSVFile, Output, ParquetFile};
@@ -12,8 +13,6 @@ use crate::util::parser::parse as parse_erd;
 use crate::util::scanner::scan as scan_erd;
 type RunResult<T> = Result<T, Box<dyn Error>>;
 
-// D1: re-export dialect API so D2's `--target` CLI flag and DDL emitter can
-// reach it without poking through `util::`.
 pub use util::dialect::{to_sql_type, Dialect, DialectError};
 
 /// Output format selector for the `er` subcommand.
@@ -61,6 +60,8 @@ pub fn run_er(
     Ok(())
 }
 
+// D3 will add --no-load and --no-data; consolidate into a struct then.
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     schema: Option<String>,
     rows: usize,
@@ -69,6 +70,8 @@ pub fn run(
     parquet: bool,
     append_target: Option<String>,
     delete_target: Option<String>,
+    target: Option<Dialect>,
+    no_ddl: bool,
 ) -> RunResult<()> {
     let csv = csv || !parquet;
 
@@ -76,6 +79,12 @@ pub fn run(
         return Err(
             "--parquet output requires --file-target <PATH>; refusing to discard generated rows"
                 .into(),
+        );
+    }
+
+    if target.is_some() && file_target.is_none() {
+        return Err(
+            "--target requires --file-target so the DDL file can be placed next to the data".into(),
         );
     }
 
@@ -93,13 +102,30 @@ pub fn run(
         None => default_schema(),
     };
 
-    let mut data_frame = create_dataframe(tokenized_schema, rows, append_target, delete_target)
-        .map_err(|e| format!("failed to build dataframe: {e}"))?;
+    let mut data_frame =
+        create_dataframe(tokenized_schema.clone(), rows, append_target, delete_target)
+            .map_err(|e| format!("failed to build dataframe: {e}"))?;
 
-    match (csv, parquet, file_target) {
-        (_, true, Some(path)) => ParquetFile { file_name: path }.write(&mut data_frame)?,
-        (true, _, Some(path)) => CSVFile { file_name: path }.write(&mut data_frame)?,
+    match (csv, parquet, &file_target) {
+        (_, true, Some(path)) => ParquetFile {
+            file_name: path.clone(),
+        }
+        .write(&mut data_frame)?,
+        (true, _, Some(path)) => CSVFile {
+            file_name: path.clone(),
+        }
+        .write(&mut data_frame)?,
         _ => Console {}.write(&mut data_frame)?,
+    }
+
+    if let (Some(dialect), Some(ref path), false) = (target, &file_target, no_ddl) {
+        let table = table_name_from_path(path);
+        let ddl = emit_create_table(table, &tokenized_schema, dialect)
+            .map_err(|e| format!("DDL emit failed: {e}"))?;
+        let out_path = ddl_path(path, dialect);
+        std::fs::write(&out_path, &ddl)
+            .map_err(|e| format!("failed to write DDL file '{out_path}': {e}"))?;
+        eprintln!("wrote {out_path}");
     }
 
     Ok(())
@@ -119,13 +145,25 @@ mod test {
             true,
             None,
             None,
+            None,
+            false,
         );
         assert!(result.is_err());
     }
 
     #[test]
     fn empty_schema_returns_descriptive_error() {
-        let result = run(Some("".to_string()), 3, None, true, false, None, None);
+        let result = run(
+            Some("".to_string()),
+            3,
+            None,
+            true,
+            false,
+            None,
+            None,
+            None,
+            false,
+        );
         assert!(result.is_err());
     }
 
@@ -140,6 +178,8 @@ mod test {
             false,
             None,
             None,
+            None,
+            false,
         );
         assert!(result.is_ok());
         assert!(path.exists());
@@ -157,6 +197,8 @@ mod test {
             true,
             None,
             None,
+            None,
+            false,
         );
         assert!(result.is_ok());
         assert!(path.exists());
@@ -173,13 +215,15 @@ mod test {
             false,
             Some("/nonexistent/file.parquet".to_string()),
             None,
+            None,
+            false,
         );
         assert!(result.is_err());
     }
 
     #[test]
     fn run_default_schema_succeeds() {
-        let result = run(None, 5, None, true, false, None, None);
+        let result = run(None, 5, None, true, false, None, None, None, false);
         assert!(result.is_ok());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ struct FlatArgs {
     /// Delete rows by index 1 or 1,2,3 or 1-3
     #[arg(short, long)]
     delete_target: Option<String>,
+    /// Emit a dialect-correct CREATE TABLE DDL file next to the data file
+    #[arg(long, value_enum)]
+    target: Option<gencsv::Dialect>,
+    /// Suppress DDL emission when --target is set
+    #[arg(long)]
+    no_ddl: bool,
 }
 
 #[derive(CLAPArgs)]
@@ -100,6 +106,8 @@ fn main() {
             cli.flat.parquet,
             cli.flat.append_target,
             cli.flat.delete_target,
+            cli.flat.target,
+            cli.flat.no_ddl,
         ),
     };
     if let Err(e) = result {

--- a/src/util/ddl.rs
+++ b/src/util/ddl.rs
@@ -1,0 +1,183 @@
+//! DDL emitter for D2 of `.claude/prds/db-target-types.prd.md`.
+//!
+//! Produces a `CREATE TABLE` statement from a gencsv flat-table schema and a
+//! target dialect. The first `INT_INC` column is treated as the primary key;
+//! subsequent `INT_INC` columns are non-PK. FK constraints are deferred to D5
+//! where the ER AST provides the relational context.
+
+use crate::util::dialect::{to_sql_type, Dialect, DialectError};
+use crate::util::schema::Schema;
+
+/// Emit a `CREATE TABLE` DDL string for `table_name` using `columns` and
+/// `dialect`. Returns an error only if a column's type has no mapping for the
+/// chosen dialect (i.e. `to_sql_type` fails).
+pub fn emit_create_table(
+    table_name: &str,
+    columns: &[Schema],
+    dialect: Dialect,
+) -> Result<String, DialectError> {
+    let mut pk_seen = false;
+    let mut col_defs: Vec<String> = Vec::with_capacity(columns.len());
+
+    for col in columns {
+        let is_pk = col.datatype == "INT_INC" && !pk_seen;
+        if is_pk {
+            pk_seen = true;
+        }
+        let sql_type = to_sql_type(&col.datatype, dialect, is_pk)?;
+        col_defs.push(format!("  {} {}", col.name, sql_type));
+    }
+
+    Ok(format!(
+        "CREATE TABLE {} (\n{}\n);\n",
+        table_name,
+        col_defs.join(",\n")
+    ))
+}
+
+/// Derive the DDL output path from a data file path.
+///
+/// `data_path` is the `--file-target` value (e.g. `"./out/users.csv"`).
+/// Returns e.g. `"./out/users.ddl.postgres.sql"`.
+pub fn ddl_path(data_path: &str, dialect: Dialect) -> String {
+    let stem = data_path
+        .strip_suffix(".csv")
+        .or_else(|| data_path.strip_suffix(".parquet"))
+        .unwrap_or(data_path);
+    format!("{}.ddl.{}.sql", stem, dialect.as_str())
+}
+
+/// Derive the table name from a data file path (basename without extension).
+pub fn table_name_from_path(data_path: &str) -> &str {
+    let path = std::path::Path::new(data_path);
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(data_path)
+}
+
+mod test {
+    #![allow(unused_imports, dead_code)]
+    use super::*;
+    use crate::util::dialect::Dialect;
+    use crate::util::schema::Schema;
+
+    fn col(name: &str, datatype: &str) -> Schema {
+        Schema {
+            name: name.into(),
+            datatype: datatype.into(),
+            modifier: None,
+        }
+    }
+
+    #[test]
+    fn postgres_create_table_has_correct_shape() {
+        let cols = vec![col("id", "INT_INC"), col("name", "STRING")];
+        let ddl = emit_create_table("users", &cols, Dialect::Postgres).unwrap();
+        assert!(ddl.starts_with("CREATE TABLE users ("), "got: {ddl}");
+        assert!(ddl.contains("id SERIAL PRIMARY KEY"), "got: {ddl}");
+        assert!(ddl.contains("name TEXT"), "got: {ddl}");
+        assert!(ddl.ends_with(");\n"), "got: {ddl}");
+    }
+
+    #[test]
+    fn mysql_uses_auto_increment_for_first_int_inc() {
+        let cols = vec![col("id", "INT_INC"), col("seq", "INT_INC")];
+        let ddl = emit_create_table("t", &cols, Dialect::Mysql).unwrap();
+        assert!(
+            ddl.contains("id INT AUTO_INCREMENT PRIMARY KEY"),
+            "got: {ddl}"
+        );
+        assert!(ddl.contains("seq INT NOT NULL"), "got: {ddl}");
+    }
+
+    #[test]
+    fn sqlserver_uses_identity_for_pk() {
+        let cols = vec![col("id", "INT_INC"), col("email", "STRING")];
+        let ddl = emit_create_table("accts", &cols, Dialect::Sqlserver).unwrap();
+        assert!(
+            ddl.contains("id INT IDENTITY(1,1) PRIMARY KEY"),
+            "got: {ddl}"
+        );
+        assert!(ddl.contains("email NVARCHAR(255)"), "got: {ddl}");
+    }
+
+    #[test]
+    fn bigquery_no_native_pk_decoration() {
+        let cols = vec![col("id", "INT_INC"), col("price", "DECIMAL")];
+        let ddl = emit_create_table("orders", &cols, Dialect::Bigquery).unwrap();
+        assert!(ddl.contains("id INT64"), "got: {ddl}");
+        assert!(ddl.contains("price NUMERIC"), "got: {ddl}");
+    }
+
+    #[test]
+    fn all_types_round_trip_without_error() {
+        let types = [
+            "INT_INC",
+            "INT",
+            "INT_RNG",
+            "DIGIT",
+            "DECIMAL",
+            "PRICE",
+            "STRING",
+            "VALUE",
+            "DATE",
+            "TIME",
+            "DATE_TIME",
+            "NAME",
+            "FIRST_NAME",
+            "LAST_NAME",
+            "SSN",
+            "ZIP_CODE",
+            "COUNTRY_CODE",
+            "STATE_NAME",
+            "STATE_ABBR",
+            "LAT",
+            "LON",
+            "PHONE",
+            "LOREM_WORD",
+            "LOREM_TITLE",
+            "LOREM_SENTENCE",
+            "LOREM_PARAGRAPH",
+            "UUID",
+        ];
+        for dialect in [
+            Dialect::Mysql,
+            Dialect::Postgres,
+            Dialect::Sqlserver,
+            Dialect::Bigquery,
+            Dialect::Spark,
+        ] {
+            let cols: Vec<Schema> = types.iter().map(|t| col(t, t)).collect();
+            let result = emit_create_table("all_types", &cols, dialect);
+            assert!(result.is_ok(), "dialect={dialect:?}: {result:?}");
+        }
+    }
+
+    #[test]
+    fn ddl_path_strips_csv_extension() {
+        assert_eq!(
+            ddl_path("./out/users.csv", Dialect::Postgres),
+            "./out/users.ddl.postgres.sql"
+        );
+    }
+
+    #[test]
+    fn ddl_path_strips_parquet_extension() {
+        assert_eq!(
+            ddl_path("/data/orders.parquet", Dialect::Mysql),
+            "/data/orders.ddl.mysql.sql"
+        );
+    }
+
+    #[test]
+    fn ddl_path_appends_when_no_known_extension() {
+        assert_eq!(ddl_path("output", Dialect::Spark), "output.ddl.spark.sql");
+    }
+
+    #[test]
+    fn table_name_from_path_strips_dir_and_extension() {
+        assert_eq!(table_name_from_path("./out/users.csv"), "users");
+        assert_eq!(table_name_from_path("/data/orders.parquet"), "orders");
+        assert_eq!(table_name_from_path("plain"), "plain");
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod dataframe;
+pub mod ddl;
 pub mod dialect;
 pub mod erd_ast;
 pub mod fake;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -176,3 +176,71 @@ fn test_flat_mode_still_works_after_subcommand_refactor() -> TestResult {
         .stdout(predicate::str::contains("id,name"));
     Ok(())
 }
+
+#[test]
+fn test_target_postgres_writes_ddl_file() -> TestResult {
+    let data = std::env::temp_dir().join("gencsv_ddl_test_users.csv");
+    let ddl = std::env::temp_dir().join("gencsv_ddl_test_users.ddl.postgres.sql");
+    let _ = fs::remove_file(&data);
+    let _ = fs::remove_file(&ddl);
+    Command::cargo_bin(NAME)?
+        .args([
+            "-s",
+            "id:INT_INC,name:STRING,joined:DATE",
+            "-r",
+            "3",
+            "-c",
+            "-f",
+            data.to_str().unwrap(),
+            "--target",
+            "postgres",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("ddl.postgres.sql"));
+    assert!(data.exists(), "data file missing");
+    assert!(ddl.exists(), "DDL file missing");
+    let golden = fs::read_to_string("tests/fixtures/dialects/users.ddl.postgres.sql")?;
+    let actual = fs::read_to_string(&ddl)?;
+    assert_eq!(actual, golden, "DDL content mismatch");
+    let _ = fs::remove_file(&data);
+    let _ = fs::remove_file(&ddl);
+    Ok(())
+}
+
+#[test]
+fn test_target_without_file_target_is_rejected() -> TestResult {
+    Command::cargo_bin(NAME)?
+        .args(["-s", "id:INT_INC", "-r", "3", "--target", "mysql"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--target requires --file-target"));
+    Ok(())
+}
+
+#[test]
+fn test_no_ddl_suppresses_ddl_file() -> TestResult {
+    let data = std::env::temp_dir().join("gencsv_no_ddl_test.csv");
+    let ddl = std::env::temp_dir().join("gencsv_no_ddl_test.ddl.mysql.sql");
+    let _ = fs::remove_file(&data);
+    let _ = fs::remove_file(&ddl);
+    Command::cargo_bin(NAME)?
+        .args([
+            "-s",
+            "id:INT_INC",
+            "-r",
+            "2",
+            "-c",
+            "-f",
+            data.to_str().unwrap(),
+            "--target",
+            "mysql",
+            "--no-ddl",
+        ])
+        .assert()
+        .success();
+    assert!(data.exists(), "data file missing");
+    assert!(!ddl.exists(), "DDL file should not exist with --no-ddl");
+    let _ = fs::remove_file(&data);
+    Ok(())
+}

--- a/tests/fixtures/dialects/users.ddl.postgres.sql
+++ b/tests/fixtures/dialects/users.ddl.postgres.sql
@@ -1,0 +1,5 @@
+CREATE TABLE gencsv_ddl_test_users (
+  id SERIAL PRIMARY KEY,
+  name TEXT,
+  joined DATE
+);


### PR DESCRIPTION
## Summary

- **`src/util/ddl.rs`** (new): `emit_create_table` builds a dialect-correct `CREATE TABLE` statement from the gencsv schema. First `INT_INC` column gets PK decoration (e.g. `SERIAL PRIMARY KEY`, `INT AUTO_INCREMENT PRIMARY KEY`, `INT IDENTITY(1,1) PRIMARY KEY`). `ddl_path` and `table_name_from_path` helpers derive output paths from `--file-target`.
- **`--target <DIALECT>`** flag on flat-table mode: emits `<stem>.ddl.<dialect>.sql` alongside the data file.
- **`--no-ddl`** flag: suppresses DDL emission when `--target` is set.
- **Guard**: `--target` without `--file-target` exits non-zero with a clear message.
- **105 unit tests + 16 CLI integration tests** all pass.

## Test plan

- [ ] `cargo test` green
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `gencsv -s "id:INT_INC,name:STRING" -r 5 -c -f /tmp/u.csv --target postgres` → writes `u.csv` + `u.ddl.postgres.sql` with `SERIAL PRIMARY KEY`
- [ ] `gencsv -s "id:INT_INC" -r 3 --target mysql` → exits non-zero, mentions `--file-target`
- [ ] `gencsv -s "id:INT_INC" -r 3 -c -f /tmp/t.csv --target mysql --no-ddl` → writes `t.csv` only