### PR TITLE
chore: rename project to synthtab

### DIFF
--- a/.claude/plans/db-target-types-d1.plan.md
+++ b/.claude/plans/db-target-types-d1.plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Land the foundational `Dialect` enum and the full `gencsv-type × dialect → SQL-type-string` mapping table from PRD §6.2 as a pure-library module with no I/O, no CLI changes, no `Output` sink. This milestone is a lookup table behind a small API; everything else (DDL emission, load commands, Parquet logical types, ER integration) is layered on top of it in D2–D5. Choosing to land this independently of the ER work is deliberate — D1 has zero behavioural overlap with ER and no shared files, so it can ship in parallel.
+Land the foundational `Dialect` enum and the full `synthtab-type × dialect → SQL-type-string` mapping table from PRD §6.2 as a pure-library module with no I/O, no CLI changes, no `Output` sink. This milestone is a lookup table behind a small API; everything else (DDL emission, load commands, Parquet logical types, ER integration) is layered on top of it in D2–D5. Choosing to land this independently of the ER work is deliberate — D1 has zero behavioural overlap with ER and no shared files, so it can ship in parallel.
 
 ## Patterns to Mirror
 
@@ -34,12 +34,12 @@ impl Dialect {
 
 pub struct DialectError { pub message: String }   // Display + Error
 
-pub fn to_sql_type(gencsv_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError>;
+pub fn to_sql_type(synthtab_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError>;
 ```
 
 All 24 rows in PRD §6.2 must be covered. `is_pk` only changes the output for `INT_INC` (per the PRD table: PK gets `INT AUTO_INCREMENT PRIMARY KEY` / `SERIAL PRIMARY KEY` / etc., non-PK gets `INT NOT NULL` / `INTEGER NOT NULL` / etc.). For all other types, `is_pk` is accepted but ignored — we don't decorate non-`INT_INC` PKs in D1.
 
-Unknown `gencsv_type` returns `Err(DialectError { message: "type 'foo' has no '{dialect}' mapping; supported mappings: see docs/DIALECTS.md" })` per PRD §7. The `docs/DIALECTS.md` reference is forward-looking — file lands in D6, but the error string must be present from D1 so we don't need to update it later.
+Unknown `synthtab_type` returns `Err(DialectError { message: "type 'foo' has no '{dialect}' mapping; supported mappings: see docs/DIALECTS.md" })` per PRD §7. The `docs/DIALECTS.md` reference is forward-looking — file lands in D6, but the error string must be present from D1 so we don't need to update it later.
 
 **Explicitly NOT in D1**: no `Output` trait impl, no file emission, no CLI flag, no DDL string assembly (`CREATE TABLE ...`), no load-command rendering, no Parquet logical-type wiring, no schema.rs changes. Those are D2–D5.
 
@@ -87,8 +87,8 @@ No changes to `src/main.rs`, `src/lib.rs`, `src/util/schema.rs`, `src/util/fake.
 
 - Implementation shape:
   ```rust
-  pub fn to_sql_type(gencsv_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError> {
-      let mapped = match (dialect, gencsv_type) {
+  pub fn to_sql_type(synthtab_type: &str, dialect: Dialect, is_pk: bool) -> Result<String, DialectError> {
+      let mapped = match (dialect, synthtab_type) {
           (Dialect::Mysql,    "INT_INC") if is_pk => "INT AUTO_INCREMENT PRIMARY KEY",
           (Dialect::Mysql,    "INT_INC")           => "INT NOT NULL",
           (Dialect::Postgres, "INT_INC") if is_pk => "SERIAL PRIMARY KEY",
@@ -114,7 +114,7 @@ No changes to `src/main.rs`, `src/lib.rs`, `src/util/schema.rs`, `src/util/fake.
 - **Validate**: `cargo test dialect` — all green.
 
 ### Task 5: Quality gates + commit
-- **Action**: Run the full pre-commit suite. Conventional commit: `feat: add Dialect enum and gencsv-type -> SQL-type mapping (D1)`.
+- **Action**: Run the full pre-commit suite. Conventional commit: `feat: add Dialect enum and synthtab-type -> SQL-type mapping (D1)`.
 - **Validate**: see Validation block below.
 
 ## Validation
@@ -143,7 +143,7 @@ Coverage gate (`cargo llvm-cov --fail-under-lines 80`) is a D6 acceptance criter
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | Mapping table row drift between PRD §6.2 and `to_sql_type` implementation | **High** | Single source of truth in `dialect.rs`. When D6 ships `docs/DIALECTS.md`, the doc gets generated from a table-driven test or a const slice — not maintained by hand. For D1, the `every_type_in_readme_has_at_least_one_dialect_mapping` test guarantees coverage. |
-| Type-string mismatch between `gencsv` schema and `to_sql_type` keys (e.g. `"INT"` vs `"int"`) | High | `create_column` in `src/util/fake.rs:60` matches uppercase. `to_sql_type` must take the same uppercase key. Add a doc comment on `to_sql_type` pinning this contract: `/// `gencsv_type` must be one of the uppercase keys accepted by `create_column`.` |
+| Type-string mismatch between `synthtab` schema and `to_sql_type` keys (e.g. `"INT"` vs `"int"`) | High | `create_column` in `src/util/fake.rs:60` matches uppercase. `to_sql_type` must take the same uppercase key. Add a doc comment on `to_sql_type` pinning this contract: `/// `synthtab_type` must be one of the uppercase keys accepted by `create_column`.` |
 | `clap::ValueEnum` derive adds a build dependency we didn't intend | Low | Clap derive is already on per CLAUDE.md (`clap = "4.5 derive"`). No new crate. |
 | `Dialect::from_str` collides with `std::str::FromStr` trait impl readers might expect | Low | Implement as inherent method `from_str(s: &str) -> Result<Self, DialectError>` rather than the `FromStr` trait — keeps error type local, avoids `std::str::FromStr::Err` boilerplate. Document in the method's doc-comment. |
 | Future DDL emitter (D2) needs more context than `(type, dialect, is_pk)` (e.g. nullability, FK target, length override) | Medium | D1 keeps the signature minimal. D2 will likely wrap `to_sql_type` rather than change it — pass a `ColumnSpec` struct in D2 if needed. Don't pre-design that struct in D1. |

--- a/.claude/plans/er-diagram-generator-m1.plan.md
+++ b/.claude/plans/er-diagram-generator-m1.plan.md
@@ -1,13 +1,13 @@
 # Plan: ER-Diagram Generator — M1 (Scanner Port + `er` Subcommand Stub)
 
 **Source PRD**: `.claude/prds/er-diagram-generator.prd.md`
-**Selected Milestone**: M1 — Port and clean scanner from `feature/erdiagram`; add `gencsv er` subcommand stub
+**Selected Milestone**: M1 — Port and clean scanner from `feature/erdiagram`; add `synthtab er` subcommand stub
 **Target branch**: `feature/erd-v2` (fresh from `main`)
 **Complexity**: Medium
 
 ## Summary
 
-Port the salvageable scanner (`src/util/scanner.rs`, 338 lines) from the abandoned `feature/erdiagram` branch into a fresh `feature/erd-v2` branch, hardened to the repo's post-quality-pass standards. Add a `gencsv er <FILE>` clap subcommand that parses CLI args, reads the file, runs the scanner, and prints a token stream (no parser, no generator yet). This milestone produces a working CLI surface and a tested tokenizer ready for M2's parser.
+Port the salvageable scanner (`src/util/scanner.rs`, 338 lines) from the abandoned `feature/erdiagram` branch into a fresh `feature/erd-v2` branch, hardened to the repo's post-quality-pass standards. Add a `synthtab er <FILE>` clap subcommand that parses CLI args, reads the file, runs the scanner, and prints a token stream (no parser, no generator yet). This milestone produces a working CLI surface and a tested tokenizer ready for M2's parser.
 
 ## Patterns to Mirror
 
@@ -27,8 +27,8 @@ Port the salvageable scanner (`src/util/scanner.rs`, 338 lines) from the abandon
 - Salvage **only** `src/util/scanner.rs` from `feature/erdiagram`. The branch's other files regressed code quality and must be ignored.
 - Promote scanner to current quality bar: no `unwrap()` outside tests/unreachable paths, `OnceLock`-cached regexes, line-numbered error messages, immutable-by-default style.
 - Token model must distinguish at minimum: `Keyword(erDiagram)`, `Ident(String)`, `LBrace`, `RBrace`, `Colon`, `Cardinality(String)` (raw glyph, e.g. `||--o{`), `Newline`, `Comment(String)`. Final shape gets cemented when the parser arrives in M2; M1 only needs a stable enough emission to round-trip the §6 examples from the PRD.
-- Add `gencsv er <FILE> [--rows N] [--rows-per K=V]... [--out DIR] [--format csv|parquet]` clap subcommand. Flags must parse correctly but be **stored unused** in M1 (parser/generator land in M2/M3). The only required runtime behaviour: open `<FILE>`, run scanner, print token-per-line debug dump to stdout, exit 0 on clean scan and non-zero with a line-numbered error otherwise.
-- Existing flag-based mode (`gencsv -s …`) must continue to work unchanged. Adding a subcommand is a breaking change to clap structure unless we use a default-subcommand pattern — see "Risks" below for the chosen approach.
+- Add `synthtab er <FILE> [--rows N] [--rows-per K=V]... [--out DIR] [--format csv|parquet]` clap subcommand. Flags must parse correctly but be **stored unused** in M1 (parser/generator land in M2/M3). The only required runtime behaviour: open `<FILE>`, run scanner, print token-per-line debug dump to stdout, exit 0 on clean scan and non-zero with a line-numbered error otherwise.
+- Existing flag-based mode (`synthtab -s …`) must continue to work unchanged. Adding a subcommand is a breaking change to clap structure unless we use a default-subcommand pattern — see "Risks" below for the chosen approach.
 - Two integration test fixtures: one valid `.mmd` file, one with an unsupported glyph that asserts a line-numbered error.
 
 ## Files to Change
@@ -83,7 +83,7 @@ Port the salvageable scanner (`src/util/scanner.rs`, 338 lines) from the abandon
       Er(ErArgs),
   }
   ```
-  Dispatch: `Some(Er(a)) => gencsv::run_er(...)`, `None => gencsv::run(...)` (existing behaviour preserved).
+  Dispatch: `Some(Er(a)) => synthtab::run_er(...)`, `None => synthtab::run(...)` (existing behaviour preserved).
 - **Mirror**: `src/main.rs:5-29` for short+long flag style on `ErArgs`; defaults via `default_value_t`.
 - **Validate**: `cargo build --release` succeeds. `cargo run -- --help` shows both flat-table flags and the `er` subcommand. `cargo run -- -s "a:INT" -r 3` still works (regression check).
 
@@ -133,7 +133,7 @@ Coverage (`cargo llvm-cov --fail-under-lines 80`) is listed as an M5 acceptance 
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| Clap subcommand refactor breaks existing flag-based mode | **High** | Use `Option<Subcommand>` + `#[command(flatten)] FlatArgs` so `gencsv -s ... -r 3` still parses with no subcommand. Add a regression integration test before refactor. |
+| Clap subcommand refactor breaks existing flag-based mode | **High** | Use `Option<Subcommand>` + `#[command(flatten)] FlatArgs` so `synthtab -s ... -r 3` still parses with no subcommand. Add a regression integration test before refactor. |
 | Salvaged scanner has hidden `unwrap()` panics on malformed input | Medium | Task 2 writes failing tests for malformed input first; Task 3 cannot pass without `?`-propagation throughout. |
 | Token enum design choices in M1 prove wrong for M2 parser | Medium | Keep `Token` `pub(crate)`, not `pub`, so M2 can refactor freely. Scope M1 to round-tripping the PRD §6 examples; resist designing for the parser. |
 | Scanner port pulls in a new crate not on the CLAUDE.md pin list | Low | Audit `feature/erdiagram` scanner imports before porting; reject any new dep unless justified in a separate PR. Current code already has `regex` + `std`. |
@@ -144,9 +144,9 @@ Coverage (`cargo llvm-cov --fail-under-lines 80`) is listed as an M5 acceptance 
 
 - [ ] `feature/erd-v2` branch cut fresh from `main`
 - [ ] `src/util/scanner.rs` exists with `pub enum Token`, `pub fn scan`, inline tests, no `unwrap()` outside tests
-- [ ] `gencsv er <FILE>` parses and dumps tokens line-by-line
-- [ ] `gencsv -s "..." -r N` continues to work unchanged (regression-tested)
-- [ ] `gencsv er tests/fixtures/er/invalid_glyph.mmd` exits non-zero with `line N: non-identifying relationships ('..') not supported; use '--'`
+- [ ] `synthtab er <FILE>` parses and dumps tokens line-by-line
+- [ ] `synthtab -s "..." -r N` continues to work unchanged (regression-tested)
+- [ ] `synthtab er tests/fixtures/er/invalid_glyph.mmd` exits non-zero with `line N: non-identifying relationships ('..') not supported; use '--'`
 - [ ] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green
 - [ ] No new crate added to `Cargo.toml` (scanner uses only existing deps)
 - [ ] M1 row in PRD §8 marked `in-progress` with link to this plan

--- a/.claude/prds/db-target-types.prd.md
+++ b/.claude/prds/db-target-types.prd.md
@@ -10,7 +10,7 @@
 
 ## 1. Problem
 
-`gencsv` produces CSV (typeless) and Parquet (typed, but generically). Users importing into MySQL, Postgres, SQL Server, BigQuery, or Spark have to:
+`synthtab` produces CSV (typeless) and Parquet (typed, but generically). Users importing into MySQL, Postgres, SQL Server, BigQuery, or Spark have to:
 
 1. Hand-write a `CREATE TABLE` matching the generated columns
 2. Remember the right `LOAD DATA` / `\copy` / `BULK INSERT` / `bq load` / Spark DataFrame incantation
@@ -20,12 +20,12 @@ This friction defeats the "generate fixture data fast" promise of the tool.
 
 ## 2. Goal
 
-When the user passes `--target <dialect>`, `gencsv` emits everything needed to land the data in that database:
+When the user passes `--target <dialect>`, `synthtab` emits everything needed to land the data in that database:
 
 1. Dialect-correct **Parquet logical types** (when output format is parquet)
 2. A **`CREATE TABLE` DDL file** matching the generated columns
 3. An **example load command** for the target dialect
-4. All of the above composing cleanly with both flat-table mode (`gencsv -s …`) and ER mode (`gencsv er …`)
+4. All of the above composing cleanly with both flat-table mode (`synthtab -s …`) and ER mode (`synthtab er …`)
 
 ## 3. Non-Goals
 
@@ -40,7 +40,7 @@ When the user passes `--target <dialect>`, `gencsv` emits everything needed to l
 
 | As a… | I want to… | So that… |
 |---|---|---|
-| Backend engineer | Run `gencsv -s "id:INT_INC,email:STRING" -r 5000 -c -f users.csv --target postgres` and get `users.csv` + `users.ddl.postgres.sql` + `users.load.postgres.sql` | I can `psql -f users.ddl.postgres.sql && psql -f users.load.postgres.sql` and be done |
+| Backend engineer | Run `synthtab -s "id:INT_INC,email:STRING" -r 5000 -c -f users.csv --target postgres` and get `users.csv` + `users.ddl.postgres.sql` + `users.load.postgres.sql` | I can `psql -f users.ddl.postgres.sql && psql -f users.load.postgres.sql` and be done |
 | Data engineer | Pipe an ER diagram + `--target bigquery` and get one Parquet per entity plus dialect-correct DDL | I can `bq load --source_format=PARQUET` each table directly |
 | QA engineer | See FK constraints in the emitted DDL for ER-mode output | Loading the data exercises the same referential integrity my production schema does |
 | Anyone | See a clear error if I ask for a target/type combo we don't support | I'm not chasing silent type coercions at load time |
@@ -52,14 +52,14 @@ When the user passes `--target <dialect>`, `gencsv` emits everything needed to l
 Existing commands grow three new flags:
 
 ```
-gencsv [existing flags...]
+synthtab [existing flags...]
     [--target mysql|postgres|sqlserver|bigquery|spark]
     [--no-ddl]                  # suppress DDL emission when --target is set
     [--no-load]                 # suppress load-command emission when --target is set
     [--no-data]                 # emit only DDL + load command, skip data files (handy for inspection)
 ```
 
-Same flags work on `gencsv er <FILE> --target postgres --out DIR`.
+Same flags work on `synthtab er <FILE> --target postgres --out DIR`.
 
 ### 5.2 Output bundle (one entity, target = `postgres`)
 
@@ -113,7 +113,7 @@ Caveats per dialect documented in `docs/DIALECTS.md`.
 
 ### 6.2 Type mapping table (canonical reference)
 
-| gencsv type | MySQL | Postgres | SQL Server | BigQuery | Spark |
+| synthtab type | MySQL | Postgres | SQL Server | BigQuery | Spark |
 |---|---|---|---|---|---|
 | `INT_INC` (PK) | `INT AUTO_INCREMENT PRIMARY KEY` | `SERIAL PRIMARY KEY` | `INT IDENTITY(1,1) PRIMARY KEY` | `INT64` + comment "// auto-increment not native" | `INT` + comment "// auto-increment not native" |
 | `INT_INC` (non-PK) | `INT NOT NULL` | `INTEGER NOT NULL` | `INT NOT NULL` | `INT64` | `INT` |
@@ -187,7 +187,7 @@ All errors exit non-zero and produce no partial output.
                           └────────────┬─────────────────────┘
                                        v
 ┌────────────────┐    ┌────────────────────────────────┐
-│ Schema parser  │ -> │ TypeResolver (gencsv types)    │
+│ Schema parser  │ -> │ TypeResolver (synthtab types)    │
 └────────────────┘    └────────────────┬───────────────┘
                                        │
                           ┌────────────┴────────────┐
@@ -214,7 +214,7 @@ All errors exit non-zero and produce no partial output.
 
 | File | Action | Why |
 |---|---|---|
-| `src/util/dialect.rs` | CREATE | `Dialect` enum + `to_sql_type(gencsv_type, is_pk) -> &str` per dialect; load template lookup |
+| `src/util/dialect.rs` | CREATE | `Dialect` enum + `to_sql_type(synthtab_type, is_pk) -> &str` per dialect; load template lookup |
 | `src/util/ddl.rs` | CREATE | `emit_create_table(table_name, columns, dialect) -> String`; FK constraint support |
 | `src/util/load_cmd.rs` | CREATE | Template renderer per dialect; choose file extension |
 | `src/util/output.rs` | UPDATE | Add `DdlFile`, `LoadCmdFile` sinks; teach `ParquetFile::new_for_dialect` |
@@ -255,7 +255,7 @@ Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and
 
 ## 10. Acceptance Criteria
 
-- [ ] `gencsv -s "id:INT_INC,email:STRING" -r 100 -c -f users.csv --target postgres` produces `users.csv`, `users.ddl.postgres.sql`, `users.load.postgres.sql`
+- [ ] `synthtab -s "id:INT_INC,email:STRING" -r 100 -c -f users.csv --target postgres` produces `users.csv`, `users.ddl.postgres.sql`, `users.load.postgres.sql`
 - [ ] Loading the generated bundle into the matching DB succeeds end-to-end for at least Postgres and MySQL (manual smoke test recorded in `docs/DIALECTS.md`)
 - [ ] All five dialects produce DDL that matches `tests/fixtures/dialects/*.expected.sql`
 - [ ] ER-mode + `--target` emits per-entity DDL with FK constraints in topological replay order
@@ -269,7 +269,7 @@ Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| Generated value ranges exceed target type (`fake_int()` is `i32::MAX`, doesn't fit MySQL `SMALLINT`) | High | Document safe ranges per gencsv type; defer bounded variants to Phase 2 |
+| Generated value ranges exceed target type (`fake_int()` is `i32::MAX`, doesn't fit MySQL `SMALLINT`) | High | Document safe ranges per synthtab type; defer bounded variants to Phase 2 |
 | Polars 0.38 Parquet writer doesn't expose all logical-type knobs | Medium | Use physical-type defaults where logical types aren't reachable; document gaps |
 | SQL Server `IDENTITY` columns reject inserts without `KEEPIDENTITY` | High | Emit `WITH (KEEPIDENTITY)` in the BULK INSERT template; document in DIALECTS.md |
 | BigQuery `bq` CLI requires `{dataset}` placeholder the user must fill in | Medium | Leave as `dataset` with `# TODO: replace` comment; document in DIALECTS.md |
@@ -292,7 +292,7 @@ Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and
 ## 13. References
 
 - ER PRD (sibling): [`er-diagram-generator.prd.md`](./er-diagram-generator.prd.md)
-- Current `gencsv` README: `/README.md`
+- Current `synthtab` README: `/README.md`
 - Current architecture notes: `/CLAUDE.md`
 - MySQL `LOAD DATA`: https://dev.mysql.com/doc/refman/8.0/en/load-data.html
 - Postgres `COPY`: https://www.postgresql.org/docs/current/sql-copy.html

--- a/.claude/prds/er-diagram-generator.prd.md
+++ b/.claude/prds/er-diagram-generator.prd.md
@@ -10,7 +10,7 @@
 
 ## 1. Problem
 
-`gencsv` today produces a single flat table from a `-s "col:TYPE,…"` schema. Real-world test fixtures need **multiple related tables** where foreign keys actually reference existing primary keys. Hand-wiring this with the current flag-based schema is impossible, and post-generation joining of independent flat CSVs produces broken referential integrity.
+`synthtab` today produces a single flat table from a `-s "col:TYPE,…"` schema. Real-world test fixtures need **multiple related tables** where foreign keys actually reference existing primary keys. Hand-wiring this with the current flag-based schema is impossible, and post-generation joining of independent flat CSVs produces broken referential integrity.
 
 ## 2. Goal
 
@@ -41,14 +41,14 @@ Generate **relationally-consistent multi-table synthetic data** from a **Mermaid
 New subcommand:
 
 ```
-gencsv er <FILE>
+synthtab er <FILE>
     [--rows N]                          # default row count per entity (default: 10)
     [--rows-per ENTITY=N]...            # repeatable per-entity overrides
     [--out DIR]                         # output directory (default: ./out)
     [--format csv|parquet]              # default: csv
 ```
 
-Existing flag-based mode (`gencsv -s …`) stays unchanged and becomes a peer of the `er` subcommand.
+Existing flag-based mode (`synthtab -s …`) stays unchanged and becomes a peer of the `er` subcommand.
 
 ### 5.2 Pipeline
 
@@ -95,7 +95,7 @@ This is the **complete supported grammar**. Anything outside this table is rejec
 
 ### 6.3 Attribute types
 
-| Mermaid type | gencsv generator | Notes |
+| Mermaid type | synthtab generator | Notes |
 |---|---|---|
 | `int`, `integer`, `bigint` | `INT_INC` | Sequential for PKs |
 | `string`, `varchar`, `text` | `STRING` | |
@@ -164,7 +164,7 @@ All errors include the source file path and 1-based line number where applicable
 
 | # | Milestone | Plan | Status |
 |---|---|---|---|
-| M1 | Port and clean scanner from `feature/erdiagram`; add `gencsv er` subcommand stub | [.claude/plans/er-diagram-generator-m1.plan.md](../plans/er-diagram-generator-m1.plan.md) | done |
+| M1 | Port and clean scanner from `feature/erdiagram`; add `synthtab er` subcommand stub | [.claude/plans/er-diagram-generator-m1.plan.md](../plans/er-diagram-generator-m1.plan.md) | done |
 | M2 | Parser + `ErdAst` model + validation pass (PK count, undeclared refs) | [.claude/plans/er-diagram-generator-m1.plan.md](../plans/er-diagram-generator-m1.plan.md) | done |
 | M3 | Topological generator + 1:1, 1:N, N:1 FK wiring + `MultiFileSink` | [.claude/plans/er-diagram-generator-m1.plan.md](../plans/er-diagram-generator-m1.plan.md) | done |
 | M4 | Many-to-many junction table emission | [.claude/plans/er-diagram-generator-m1.plan.md](../plans/er-diagram-generator-m1.plan.md) | done |
@@ -176,7 +176,7 @@ Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and
 
 ## 9. Acceptance Criteria
 
-- [ ] `gencsv er tests/fixtures/car_person.mmd --out /tmp/out` writes `CAR.csv`, `PERSON.csv`, `NAMED-DRIVER.csv`
+- [ ] `synthtab er tests/fixtures/car_person.mmd --out /tmp/out` writes `CAR.csv`, `PERSON.csv`, `NAMED-DRIVER.csv`
 - [ ] Every `NAMED-DRIVER.car_id` exists in `CAR.id`; every `NAMED-DRIVER.person_id` exists in `PERSON.id` (integration test asserts this)
 - [ ] M:N fixture produces a junction file with no duplicate `(a_id, b_id)` pairs
 - [ ] All errors in §7 are reproducible via fixture files and produce the documented messages
@@ -209,6 +209,6 @@ Each milestone follows the TDD workflow (test-first, RED→GREEN→refactor) and
 ## 12. References
 
 - Mermaid ER spec: https://mermaid.js.org/syntax/entityRelationshipDiagram.html
-- Current `gencsv` README: `/README.md`
+- Current `synthtab` README: `/README.md`
 - Current architecture notes: `/CLAUDE.md`
 - Abandoned exploration: `feature/erdiagram` (scanner.rs is salvageable, rest is not)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ Project-specific notes for working in this repo. General Rust/coding rules live 
 
 ## Identity
 
-- Repo dir: `gencsvrs`. Cargo crate + binary: **`gencsv`** (single `s`). `cargo install --path .` produces `gencsv`, not `gencsvrs`. README install snippet reflects this.
-- Single-binary CLI; library entry point is `gencsv::run(...)` in `src/lib.rs`.
+- Repo dir: `synthtab` (formerly `gencsvrs`). Cargo crate + binary: **`synthtab`**. `cargo install --path .` produces `synthtab`. Historical note: the binary was `gencsv` before v0.2.0.
+- Single-binary CLI; library entry point is `synthtab::run(...)` in `src/lib.rs`.
 
 ## Tech stack pins (do not bump casually)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,16 @@
 [package]
-name = "gencsv"
-version = "0.1.1"
+name = "synthtab"
+version = "0.2.0"
 edition = "2021"
+description = "Generate realistic fake tabular data with matching DDL and load scripts; ER-mode produces FK-consistent relational datasets from Mermaid erDiagrams."
+license = "MIT"
+repository = "https://github.com/jheryer/synthtab"
+homepage = "https://github.com/jheryer/synthtab"
+readme = "README.md"
+keywords = ["csv", "parquet", "fake-data", "fixtures", "test-data"]
+categories = ["command-line-utilities", "development-tools::testing"]
+authors = ["John Heryer"]
+exclude = ["out/", "target/", "tests/expected/", ".claude/", "docs/", "Cargo.lock"]
 
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# gencsv
+# synthtab
 
 A small Rust CLI that generates realistic-looking fake tabular data and writes it to **stdout**, **CSV**, or **Parquet** — optionally with matching **`CREATE TABLE` DDL** and a **load-command** script for your target database.
 
 Two modes:
 
 - **Flat mode** — one schema, one table. Great for fixtures, smoke tests, demo data.
-- **ER mode** (`gencsv er`) — generate a whole relational dataset from a [Mermaid `erDiagram`](https://mermaid.js.org/syntax/entityRelationshipDiagram.html) file, with FK values sampled from real parent PKs.
+- **ER mode** (`synthtab er`) — generate a whole relational dataset from a [Mermaid `erDiagram`](https://mermaid.js.org/syntax/entityRelationshipDiagram.html) file, with FK values sampled from real parent PKs.
 
 ```sh
-$ gencsv -s "id:INT_INC,name:NAME,email:STRING,joined:DATE" -r 5
+$ synthtab -s "id:INT_INC,name:NAME,email:STRING,joined:DATE" -r 5
 id,name,email,joined
 0,Mariana Stehr,abc...,2168-09-12
 1,Otho Becker,def...,1789-04-07
@@ -40,17 +40,17 @@ id,name,email,joined
 Requires a recent stable Rust toolchain (`rustup`).
 
 ```sh
-git clone git@github.com:jheryer/gencsvrs.git
-cd gencsvrs
+git clone git@github.com:jheryer/synthtab.git
+cd synthtab
 cargo install --path .
 ```
 
-The binary is **`gencsv`** (single `s`), not `gencsvrs`.
+The binary is **`synthtab`**.
 
 Verify:
 
 ```sh
-gencsv --version
+synthtab --version
 ```
 
 ---
@@ -59,26 +59,26 @@ gencsv --version
 
 ```sh
 # 1. Default schema, 10 rows of literal "value" — useful as a sanity check
-gencsv
+synthtab
 
 # 2. Custom schema, custom row count, CSV to stdout
-gencsv -s "id:INT_INC,name:NAME,phone:PHONE" -r 25
+synthtab -s "id:INT_INC,name:NAME,phone:PHONE" -r 25
 
 # 3. Write 1,000 rows to a CSV file
-gencsv -s "id:INT_INC,city:STATE_NAME" -r 1000 -c -f cities.csv
+synthtab -s "id:INT_INC,city:STATE_NAME" -r 1000 -c -f cities.csv
 
 # 4. Write 1,000 rows to a Parquet file
-gencsv -s "id:INT_INC,price:PRICE" -r 1000 -p -f prices.parquet
+synthtab -s "id:INT_INC,price:PRICE" -r 1000 -p -f prices.parquet
 
 # 5. Generate CSV + a Postgres CREATE TABLE + a \copy snippet in one shot
-gencsv -s "id:INT_INC,email:STRING,joined:DATE" -r 500 \
+synthtab -s "id:INT_INC,email:STRING,joined:DATE" -r 500 \
        -c -f users.csv --target postgres
 # → users.csv
 # → users.ddl.postgres.sql
 # → users.load.postgres.sql
 
 # 6. Generate a whole relational dataset from an ER diagram
-gencsv er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data --target mysql
+synthtab er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data --target mysql
 ```
 
 ---
@@ -89,48 +89,48 @@ gencsv er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data --target mysql
 
 ```sh
 # Count generated rows
-gencsv -s "id:INT_INC" -r 1000000 | wc -l
+synthtab -s "id:INT_INC" -r 1000000 | wc -l
 
 # Load directly into DuckDB
-gencsv -s "id:INT_INC,price:PRICE,ts:DATE_TIME" -r 50000 \
+synthtab -s "id:INT_INC,price:PRICE,ts:DATE_TIME" -r 50000 \
   | duckdb -c "CREATE TABLE events AS SELECT * FROM read_csv_auto('/dev/stdin');"
 
 # Pipe into psql
-gencsv -s "id:INT_INC,email:STRING" -r 10000 \
+synthtab -s "id:INT_INC,email:STRING" -r 10000 \
   | psql -c "\copy users(id,email) FROM STDIN WITH (FORMAT csv, HEADER true)"
 ```
 
 ### A user-signup fixture
 
 ```sh
-gencsv -s "id:INT_INC,first:FIRST_NAME,last:LAST_NAME,email:STRING,signup:DATE_TIME" \
+synthtab -s "id:INT_INC,first:FIRST_NAME,last:LAST_NAME,email:STRING,signup:DATE_TIME" \
        -r 10000 -c -f users.csv
 ```
 
 ### A geo-tagged events Parquet for pyarrow / Spark / Polars tests
 
 ```sh
-gencsv -s "id:UUID,lat:LAT,lon:LON,city:STATE_NAME,observed:DATE_TIME" \
+synthtab -s "id:UUID,lat:LAT,lon:LON,city:STATE_NAME,observed:DATE_TIME" \
        -r 100000 -p -f tests/fixtures/events.parquet
 ```
 
 ### Sequential integers in a range (signed lower bound is fine)
 
 ```sh
-gencsv -s "id:INT_INC,delta:INT_RNG:(-50-50)" -r 100 -c -f range.csv
+synthtab -s "id:INT_INC,delta:INT_RNG:(-50-50)" -r 100 -c -f range.csv
 ```
 
 ### Currency + decimals for a billing fixture
 
 ```sh
-gencsv -s "invoice_id:UUID,amount:PRICE,tax:DECIMAL,paid_on:DATE" \
+synthtab -s "invoice_id:UUID,amount:PRICE,tax:DECIMAL,paid_on:DATE" \
        -r 5000 -c -f invoices.csv
 ```
 
 ### Mixed lorem text for content placeholders
 
 ```sh
-gencsv -s "id:INT_INC,title:LOREM_TITLE,body:LOREM_PARAGRAPH,slug:LOREM_WORD" \
+synthtab -s "id:INT_INC,title:LOREM_TITLE,body:LOREM_PARAGRAPH,slug:LOREM_WORD" \
        -r 250 -c -f posts.csv
 ```
 
@@ -138,7 +138,7 @@ gencsv -s "id:INT_INC,title:LOREM_TITLE,body:LOREM_PARAGRAPH,slug:LOREM_WORD" \
 
 ```sh
 # yesterday's file: prices.parquet (same schema)
-gencsv -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 1000 \
+synthtab -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 1000 \
        -p -f prices.parquet -a prices.parquet
 ```
 
@@ -148,26 +148,26 @@ The combined frame (yesterday + today) is written back to `prices.parquet`. Sche
 
 ```sh
 # Drop a single row
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 7
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 7
 
 # Drop rows 0–9
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 0-9
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 0-9
 
 # Drop a comma list
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 0,2,4,6,8
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 50 -d 0,2,4,6,8
 
 # Drop a random subset (count + indexes both randomized)
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 50 -d random
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 50 -d random
 
 # Negative-starting range needs the = form so clap doesn't read the leading - as a flag
-gencsv -s "id:INT_RNG:(-5-10),note:STRING" -r 16 --delete-target=-2-2
+synthtab -s "id:INT_RNG:(-5-10),note:STRING" -r 16 --delete-target=-2-2
 ```
 
 ---
 
 ## ER mode examples
 
-`gencsv er` reads a Mermaid `erDiagram`, writes one file per entity, and **auto-wires FK columns** by sampling from the parent's PK column — so the dataset is referentially consistent out of the box.
+`synthtab er` reads a Mermaid `erDiagram`, writes one file per entity, and **auto-wires FK columns** by sampling from the parent's PK column — so the dataset is referentially consistent out of the box.
 
 ### Minimal: customers + orders
 
@@ -190,7 +190,7 @@ erDiagram
 ```
 
 ```sh
-gencsv er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data
+synthtab er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data
 # → data/CUSTOMER.csv   (500 rows)
 # → data/ORDER.csv      (2 000 rows, customer_id ∈ CUSTOMER.id)
 ```
@@ -198,7 +198,7 @@ gencsv er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data
 ### Parquet output
 
 ```sh
-gencsv er shop.mmd -r 500 --out ./data -F parquet
+synthtab er shop.mmd -r 500 --out ./data -F parquet
 # → data/CUSTOMER.parquet
 # → data/ORDER.parquet
 ```
@@ -215,7 +215,7 @@ erDiagram
 ```
 
 ```sh
-gencsv er enrollments.mmd -r 200 --rows-per STUDENT_COURSE=5000 --out ./data
+synthtab er enrollments.mmd -r 200 --rows-per STUDENT_COURSE=5000 --out ./data
 # → data/STUDENT.csv
 # → data/COURSE.csv
 # → data/STUDENT_COURSE.csv  (junction table with both FKs)
@@ -233,7 +233,7 @@ erDiagram
 ```
 
 ```sh
-gencsv er retail.mmd \
+synthtab er retail.mmd \
        -r 10 \
        --rows-per STORE=200 \
        --rows-per PRODUCT=10000 \
@@ -262,7 +262,7 @@ Add `--target <dialect>` to **flat mode** or **ER mode** and you'll get a matchi
 ### Postgres (flat mode)
 
 ```sh
-gencsv -s "id:INT_INC,name:NAME,email:STRING,joined:DATE" -r 1000 \
+synthtab -s "id:INT_INC,name:NAME,email:STRING,joined:DATE" -r 1000 \
        -c -f users.csv --target postgres
 ```
 
@@ -282,7 +282,7 @@ psql mydb -f users.load.postgres.sql
 ### MySQL (ER mode)
 
 ```sh
-gencsv er shop.mmd -r 500 --out ./data --target mysql
+synthtab er shop.mmd -r 500 --out ./data --target mysql
 # → data/CUSTOMER.csv, data/ORDER.csv
 # → data/schema.ddl.mysql.sql       (CREATE TABLE for all entities + FK constraints)
 # → data/CUSTOMER.load.mysql.sql    (LOAD DATA LOCAL INFILE)
@@ -292,7 +292,7 @@ gencsv er shop.mmd -r 500 --out ./data --target mysql
 ### SQL Server
 
 ```sh
-gencsv -s "id:INT_INC,sku:UUID,price:PRICE" -r 5000 \
+synthtab -s "id:INT_INC,sku:UUID,price:PRICE" -r 5000 \
        -c -f products.csv --target sqlserver
 # → products.ddl.sqlserver.sql  (INT IDENTITY(1,1) PRIMARY KEY, UNIQUEIDENTIFIER, DECIMAL(10,2))
 # → products.load.sqlserver.sql (BULK INSERT)
@@ -301,7 +301,7 @@ gencsv -s "id:INT_INC,sku:UUID,price:PRICE" -r 5000 \
 ### BigQuery
 
 ```sh
-gencsv -s "id:INT_INC,event:STRING,ts:DATE_TIME" -r 50000 \
+synthtab -s "id:INT_INC,event:STRING,ts:DATE_TIME" -r 50000 \
        -p -f events.parquet --target bigquery
 # → events.parquet
 # → events.ddl.bigquery.sql      (INT64, STRING, DATETIME)
@@ -311,7 +311,7 @@ gencsv -s "id:INT_INC,event:STRING,ts:DATE_TIME" -r 50000 \
 ### Spark / Databricks
 
 ```sh
-gencsv er events.mmd -r 1000 --out ./data -F parquet --target spark
+synthtab er events.mmd -r 1000 --out ./data -F parquet --target spark
 # → data/*.parquet
 # → data/schema.ddl.spark.sql
 # → data/<entity>.load.spark.py  (PySpark spark.read snippets)
@@ -320,8 +320,8 @@ gencsv er events.mmd -r 1000 --out ./data -F parquet --target spark
 ### Suppress one or the other
 
 ```sh
-gencsv -s "..." -r 100 -c -f x.csv --target postgres --no-load  # DDL only
-gencsv -s "..." -r 100 -c -f x.csv --target postgres --no-ddl   # load script only
+synthtab -s "..." -r 100 -c -f x.csv --target postgres --no-load  # DDL only
+synthtab -s "..." -r 100 -c -f x.csv --target postgres --no-ddl   # load script only
 ```
 
 Full type-mapping table and Parquet logical-type guidance: [docs/DIALECTS.md](docs/DIALECTS.md).
@@ -331,8 +331,8 @@ Full type-mapping table and Parquet logical-type guidance: [docs/DIALECTS.md](do
 ## CLI reference
 
 ```text
-gencsv [OPTIONS]                # flat mode
-gencsv er <SCHEMA.mmd> [OPTS]   # ER mode
+synthtab [OPTIONS]                # flat mode
+synthtab er <SCHEMA.mmd> [OPTS]   # ER mode
 ```
 
 ### Flat mode flags
@@ -388,7 +388,7 @@ Rules:
 
 - Whitespace around tokens is stripped (`id : INT_INC , name : NAME` works).
 - Columns that don't match `name:TYPE` or `name:TYPE:(mod)` are **skipped with a warning** on stderr; the rest of the schema still runs.
-- If **every** column is invalid, gencsv exits non-zero.
+- If **every** column is invalid, synthtab exits non-zero.
 - Unknown types fall through to the literal string `"unknown"` — typos are obvious.
 
 ---
@@ -454,10 +454,10 @@ Pipeline order is fixed:
 
 ```sh
 # Start with a 5-row baseline file
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 5 -p -f notes.parquet
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 5 -p -f notes.parquet
 
 # Append 3 more rows, then drop rows 0 and 7 from the combined 8-row frame
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 3 \
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 3 \
        -p -f notes.parquet -a notes.parquet -d 0,7
 ```
 

--- a/docs/DIALECTS.md
+++ b/docs/DIALECTS.md
@@ -1,6 +1,6 @@
 # Dialect Support
 
-`gencsv` can emit dialect-correct `CREATE TABLE` DDL and a load-command snippet alongside every generated data file.  Pass `--target <dialect>` to enable this feature.
+`synthtab` can emit dialect-correct `CREATE TABLE` DDL and a load-command snippet alongside every generated data file.  Pass `--target <dialect>` to enable this feature.
 
 ## Supported Dialects
 
@@ -14,7 +14,7 @@
 
 ## SQL Type Mapping
 
-| gencsv type | MySQL | Postgres | SQL Server | BigQuery | Spark |
+| synthtab type | MySQL | Postgres | SQL Server | BigQuery | Spark |
 |---|---|---|---|---|---|
 | `INT_INC` (PK) | `INT AUTO_INCREMENT PRIMARY KEY` | `SERIAL PRIMARY KEY` | `INT IDENTITY(1,1) PRIMARY KEY` | `INT64` | `BIGINT` |
 | `INT_INC` (non-PK) | `INT NOT NULL` | `INTEGER NOT NULL` | `INT NOT NULL` | `INT64` | `BIGINT` |
@@ -103,7 +103,7 @@ spark.read.parquet("users.parquet").write.saveAsTable("users")
 
 ## Parquet Logical Types (BigQuery and Spark)
 
-When using `--format parquet` (ER mode) or `--parquet` (flat mode) with `--target bigquery` or `--target spark`, gencsv emits a warning:
+When using `--format parquet` (ER mode) or `--parquet` (flat mode) with `--target bigquery` or `--target spark`, synthtab emits a warning:
 
 ```
 warning: --target bigquery with --format parquet: review docs/DIALECTS.md for recommended Parquet logical types
@@ -111,7 +111,7 @@ warning: --target bigquery with --format parquet: review docs/DIALECTS.md for re
 
 This warning exists because Parquet physical types must be annotated with the correct logical type to load cleanly into BigQuery and Spark.
 
-| gencsv type | Recommended Parquet logical type |
+| synthtab type | Recommended Parquet logical type |
 |---|---|
 | `DATE` | `DATE` (INT32 with DATE annotation) |
 | `TIME` | `TIME_MILLIS` or `TIME_MICROS` |
@@ -120,11 +120,11 @@ This warning exists because Parquet physical types must be annotated with the co
 | `LAT` / `LON` | `DOUBLE` |
 | `UUID` | `STRING` (UTF8) |
 
-gencsv uses polars to write Parquet, which generally applies correct annotations automatically. Review the Parquet schema with `parquet-tools schema <file>` if you encounter type mismatch errors on load.
+synthtab uses polars to write Parquet, which generally applies correct annotations automatically. Review the Parquet schema with `parquet-tools schema <file>` if you encounter type mismatch errors on load.
 
 ## ER Mode DDL
 
-In `gencsv er` mode, a single `schema.ddl.<dialect>.sql` file is written to the output directory. It contains `CREATE TABLE` statements for all entities in dependency order, plus junction tables for many-to-many relationships.
+In `synthtab er` mode, a single `schema.ddl.<dialect>.sql` file is written to the output directory. It contains `CREATE TABLE` statements for all entities in dependency order, plus junction tables for many-to-many relationships.
 
 Foreign key constraints are emitted for MySQL, PostgreSQL, and SQL Server. BigQuery and Spark do not enforce FK constraints natively, so they are omitted for those dialects.
 

--- a/docs/ERD.md
+++ b/docs/ERD.md
@@ -1,4 +1,4 @@
-# gencsv er — ER Diagram Data Generator
+# synthtab er — ER Diagram Data Generator
 
 Generate relationally-consistent multi-table CSV/Parquet data from a Mermaid
 `erDiagram` source file.
@@ -7,13 +7,13 @@ Generate relationally-consistent multi-table CSV/Parquet data from a Mermaid
 
 ```bash
 # Write 100 rows per entity to ./out/
-gencsv er schema.mmd -r 100 --out ./out
+synthtab er schema.mmd -r 100 --out ./out
 
 # Override per-entity row counts
-gencsv er schema.mmd -r 100 --rows-per ORDER=5000 --rows-per ITEM=25000
+synthtab er schema.mmd -r 100 --rows-per ORDER=5000 --rows-per ITEM=25000
 
 # Parquet output
-gencsv er schema.mmd -r 100 --out ./out -F parquet
+synthtab er schema.mmd -r 100 --out ./out -F parquet
 ```
 
 ## Supported syntax
@@ -42,7 +42,7 @@ ENTITY_NAME {
 
 ### Supported Mermaid types
 
-| Mermaid type | gencsv generator |
+| Mermaid type | synthtab generator |
 |---|---|
 | `int` | `INT_INC` (auto-increment for PK, `INT` otherwise) |
 | `string` | `STRING` |
@@ -124,7 +124,7 @@ erDiagram
 ```
 
 ```bash
-gencsv er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data
+synthtab er shop.mmd -r 500 --rows-per ORDER=2000 --out ./data
 # Writes: data/CUSTOMER.csv  (500 rows)
 #         data/ORDER.csv     (2000 rows, customer_id in CUSTOMER.id)
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
-# Using gencsv
+# Using synthtab
 
-This guide goes deeper than the README. It assumes you already have `gencsv`
+This guide goes deeper than the README. It assumes you already have `synthtab`
 installed (`cargo install --path .` from the repo root).
 
 ## Table of contents
@@ -11,13 +11,13 @@ installed (`cargo install --path .` from the repo root).
 - [Schemas in practice](#schemas-in-practice)
 - [Reproducibility and seeding](#reproducibility-and-seeding)
 - [Error messages you might see](#error-messages-you-might-see)
-- [Extending gencsv](#extending-gencsv)
+- [Extending synthtab](#extending-synthtab)
 
 ---
 
 ## Mental model
 
-A single `gencsv` invocation is one pipeline:
+A single `synthtab` invocation is one pipeline:
 
 ```
 (schema) -> generate rows -> [optional append] -> [optional delete] -> sink
@@ -42,7 +42,7 @@ If you understand that ordering, every CLI option falls into place.
 | Parquet to a file                  | `-p -f data.parquet`                   |
 | Parquet on stdout                  | **Not supported.** Always needs `-f`.  |
 
-`gencsv` will refuse to run with `-p` and no `-f`; this avoids the
+`synthtab` will refuse to run with `-p` and no `-f`; this avoids the
 silent-discard footgun that earlier versions had.
 
 ---
@@ -52,14 +52,14 @@ silent-discard footgun that earlier versions had.
 ### Seed a Postgres table
 
 ```sh
-gencsv -s "id:INT_INC,email:STRING,signup:DATE" -r 5000 -c -f users.csv
+synthtab -s "id:INT_INC,email:STRING,signup:DATE" -r 5000 -c -f users.csv
 psql -c "\copy users(id,email,signup) FROM 'users.csv' WITH (FORMAT csv, HEADER true)"
 ```
 
 ### Build a Parquet fixture for a pyarrow test
 
 ```sh
-gencsv -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 100000 \
+synthtab -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 100000 \
        -p -f tests/fixtures/prices.parquet
 ```
 
@@ -68,7 +68,7 @@ gencsv -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 100000 \
 You have `prices.parquet` from yesterday and want to append today's batch:
 
 ```sh
-gencsv -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 1000 \
+synthtab -s "ticker:STATE_ABBR,price:PRICE,ts:DATE_TIME" -r 1000 \
        -p -f prices.parquet -a prices.parquet
 ```
 
@@ -80,7 +80,7 @@ surface a clear error if they don't.
 Generate a fixture, then drop every other row out of the first 10:
 
 ```sh
-gencsv -s "id:INT_INC,note:LOREM_WORD" -r 50 \
+synthtab -s "id:INT_INC,note:LOREM_WORD" -r 50 \
        -d "0,2,4,6,8"
 ```
 
@@ -88,7 +88,7 @@ Negative-range deletes start with `-`, so use the `=` form to keep clap from
 treating the leading dash as a short flag:
 
 ```sh
-gencsv -s "id:INT_RNG:(-5-10),note:STRING" -r 16 --delete-target=-2-2
+synthtab -s "id:INT_RNG:(-5-10),note:STRING" -r 16 --delete-target=-2-2
 ```
 
 ---
@@ -114,7 +114,7 @@ bad:INT_RNG              # missing modifier -> warning, falls back to (0-rows)
 bad2:INT_RNG:(garbage)   # malformed modifier -> warning, falls back to (0-rows)
 ```
 
-When `INT_RNG`'s modifier is missing or malformed, `gencsv` writes a warning
+When `INT_RNG`'s modifier is missing or malformed, `synthtab` writes a warning
 to stderr and uses `(0-rows)` so the run still completes. If you want strict
 parsing, grep for `INT_RNG` in stderr and fail your build.
 
@@ -127,7 +127,7 @@ id:INT_INC, , name:NAME
               ^ skipped, warning on stderr
 ```
 
-If **every** column is invalid, `gencsv` exits non-zero with a message
+If **every** column is invalid, `synthtab` exits non-zero with a message
 naming the expected format.
 
 ### Unknown types
@@ -136,7 +136,7 @@ Unknown type names fall through to the literal string `"unknown"`. This makes
 typos easy to spot:
 
 ```sh
-gencsv -s "id:INT_INC,name:NMAE" -r 3
+synthtab -s "id:INT_INC,name:NMAE" -r 3
 # id,name
 # 0,unknown
 # 1,unknown
@@ -147,7 +147,7 @@ gencsv -s "id:INT_INC,name:NMAE" -r 3
 
 ## Reproducibility and seeding
 
-`gencsv` does **not** seed its random number generator. Two runs with the
+`synthtab` does **not** seed its random number generator. Two runs with the
 same flags produce different data for every type except:
 
 - `INT_INC` — always `0..rows`
@@ -155,7 +155,7 @@ same flags produce different data for every type except:
 - The default `VALUE` placeholder (literal `"value"`)
 
 If you need a deterministic fixture, build it once and commit the resulting
-CSV or Parquet file rather than re-running `gencsv` in CI.
+CSV or Parquet file rather than re-running `synthtab` in CI.
 
 ---
 
@@ -173,7 +173,7 @@ CSV or Parquet file rather than re-running `gencsv` in CI.
 
 ---
 
-## Extending gencsv
+## Extending synthtab
 
 If you want to add a new data type:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ mod test {
 
     #[test]
     fn run_csv_to_file_succeeds() {
-        let path = std::env::temp_dir().join("gencsv_lib_test_csv.csv");
+        let path = std::env::temp_dir().join("synthtab_lib_test_csv.csv");
         let result = run9(
             Some("id:INT_INC,name:VALUE".to_string()),
             5,
@@ -284,7 +284,7 @@ mod test {
 
     #[test]
     fn run_parquet_to_file_succeeds() {
-        let path = std::env::temp_dir().join("gencsv_lib_test_parquet.parquet");
+        let path = std::env::temp_dir().join("synthtab_lib_test_parquet.parquet");
         let result = run9(
             Some("id:INT_INC,name:VALUE".to_string()),
             5,
@@ -352,9 +352,9 @@ erDiagram
   CHILD { int id PK }
   PARENT ||--o{ CHILD : has
 ";
-        let dir = std::env::temp_dir().join("gencsv_run_er_test_basic");
+        let dir = std::env::temp_dir().join("synthtab_run_er_test_basic");
         let _ = std::fs::remove_dir_all(&dir);
-        let mmd = std::env::temp_dir().join("gencsv_run_er_test_basic.mmd");
+        let mmd = std::env::temp_dir().join("synthtab_run_er_test_basic.mmd");
         std::fs::write(&mmd, src).unwrap();
         let r = run_er(
             mmd.to_str().unwrap(),
@@ -381,9 +381,9 @@ erDiagram
   COURSE { int id PK }
   STUDENT }o--o{ COURSE : enrolled
 ";
-        let dir = std::env::temp_dir().join("gencsv_run_er_test_mn");
+        let dir = std::env::temp_dir().join("synthtab_run_er_test_mn");
         let _ = std::fs::remove_dir_all(&dir);
-        let mmd = std::env::temp_dir().join("gencsv_run_er_test_mn.mmd");
+        let mmd = std::env::temp_dir().join("synthtab_run_er_test_mn.mmd");
         std::fs::write(&mmd, src).unwrap();
         let r = run_er(
             mmd.to_str().unwrap(),
@@ -411,9 +411,9 @@ erDiagram
   ORDER { int id PK }
   CUSTOMER ||--o{ ORDER : places
 ";
-        let dir = std::env::temp_dir().join("gencsv_run_er_ddl_test");
+        let dir = std::env::temp_dir().join("synthtab_run_er_ddl_test");
         let _ = std::fs::remove_dir_all(&dir);
-        let mmd = std::env::temp_dir().join("gencsv_run_er_ddl_test.mmd");
+        let mmd = std::env::temp_dir().join("synthtab_run_er_ddl_test.mmd");
         std::fs::write(&mmd, src).unwrap();
         let r = run_er(
             mmd.to_str().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl From<ErFormat> for SinkFormat {
     }
 }
 
-/// Entry point for the `gencsv er <FILE>` subcommand.
+/// Entry point for the `synthtab er <FILE>` subcommand.
 #[allow(clippy::too_many_arguments)]
 pub fn run_er(
     file: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ struct FlatArgs {
     delete_target: Option<String>,
     /// Emit dialect-correct DDL and load-command files next to the data file
     #[arg(long, value_enum)]
-    target: Option<gencsv::Dialect>,
+    target: Option<synthtab::Dialect>,
     /// Suppress DDL file emission when --target is set
     #[arg(long)]
     no_ddl: bool,
@@ -72,7 +72,7 @@ struct ErArgs {
     format: ErFormat,
     /// Emit dialect-correct DDL and load-command files next to each entity file
     #[arg(long, value_enum)]
-    target: Option<gencsv::Dialect>,
+    target: Option<synthtab::Dialect>,
     /// Suppress DDL file emission when --target is set
     #[arg(long)]
     no_ddl: bool,
@@ -100,20 +100,20 @@ fn parse_rows_per(s: &str) -> Result<(String, usize), String> {
 fn main() {
     let cli = Cli::parse();
     let result = match cli.command {
-        Some(Command::Er(args)) => gencsv::run_er(
+        Some(Command::Er(args)) => synthtab::run_er(
             &args.file,
             args.rows,
             args.rows_per,
             args.out,
             match args.format {
-                ErFormat::Csv => gencsv::ErFormat::Csv,
-                ErFormat::Parquet => gencsv::ErFormat::Parquet,
+                ErFormat::Csv => synthtab::ErFormat::Csv,
+                ErFormat::Parquet => synthtab::ErFormat::Parquet,
             },
             args.target,
             args.no_ddl,
             args.no_load,
         ),
-        None => gencsv::run(
+        None => synthtab::run(
             cli.flat.schema,
             cli.flat.rows,
             cli.flat.file_target,

--- a/src/util/dataframe.rs
+++ b/src/util/dataframe.rs
@@ -212,7 +212,7 @@ mod test {
     #[test]
     fn test_data_frame_from_file_invalid_parquet_returns_err() {
         // Write garbage bytes to a temp path and try to read it as parquet.
-        let path = std::env::temp_dir().join("gencsv_bad.parquet");
+        let path = std::env::temp_dir().join("synthtab_bad.parquet");
         std::fs::write(&path, b"not a parquet file").unwrap();
         let r = data_frame_from_file(path.to_str().unwrap());
         let _ = std::fs::remove_file(&path);

--- a/src/util/ddl.rs
+++ b/src/util/ddl.rs
@@ -1,11 +1,11 @@
 //! DDL emitter (D2 + D5 of `.claude/prds/db-target-types.prd.md`).
 //!
-//! D2: flat-table `CREATE TABLE` from a gencsv schema.
+//! D2: flat-table `CREATE TABLE` from a synthtab schema.
 //! D5: ER-mode `CREATE TABLE` with FK constraints, emitted in topological order.
 
 use crate::util::dialect::{to_sql_type, Dialect, DialectError};
 use crate::util::erd_ast::{ErdAst, KeyKind};
-use crate::util::parser::mermaid_type_to_gencsv;
+use crate::util::parser::mermaid_type_to_synthtab;
 use crate::util::schema::Schema;
 
 /// Emit a `CREATE TABLE` DDL string for `table_name` using `columns` and
@@ -80,9 +80,9 @@ pub fn emit_er_ddl(
 
         // Declared columns
         for attr in &entity.attributes {
-            let gencsv_type = mermaid_type_to_gencsv(&attr.data_type).unwrap_or("STRING");
+            let synthtab_type = mermaid_type_to_synthtab(&attr.data_type).unwrap_or("STRING");
             let is_pk = attr.key == Some(KeyKind::Pk);
-            let sql_type = to_sql_type(gencsv_type, dialect, is_pk)?;
+            let sql_type = to_sql_type(synthtab_type, dialect, is_pk)?;
             col_defs.push(format!("  {} {}", attr.name, sql_type));
         }
 

--- a/src/util/dialect.rs
+++ b/src/util/dialect.rs
@@ -2,7 +2,7 @@
 //!
 //! This module exposes:
 //! - `Dialect`: the set of supported target databases
-//! - `to_sql_type`: mapping from a gencsv schema type (uppercase keys matching
+//! - `to_sql_type`: mapping from a synthtab schema type (uppercase keys matching
 //!   `src/util/fake.rs::create_column`) to a dialect-specific SQL column type
 //!   string per PRD §6.2.
 //!
@@ -67,20 +67,20 @@ impl Dialect {
     }
 }
 
-/// Map a gencsv schema type to a SQL column-type string for the given dialect.
+/// Map a synthtab schema type to a SQL column-type string for the given dialect.
 ///
-/// `gencsv_type` must be one of the uppercase keys accepted by
+/// `synthtab_type` must be one of the uppercase keys accepted by
 /// `src/util/fake.rs::create_column` (e.g. `"INT_INC"`, `"STRING"`,
 /// `"DATE_TIME"`). `is_pk` only changes the result for `"INT_INC"`; for every
 /// other type it is accepted but ignored. PK decoration of non-`INT_INC`
 /// columns is deferred to D2 where the DDL emitter has full column context.
 pub fn to_sql_type(
-    gencsv_type: &str,
+    synthtab_type: &str,
     dialect: Dialect,
     is_pk: bool,
 ) -> Result<String, DialectError> {
     use Dialect::*;
-    let mapped: &str = match (gencsv_type, dialect) {
+    let mapped: &str = match (synthtab_type, dialect) {
         // INT_INC: only type whose mapping depends on is_pk
         ("INT_INC", Mysql) if is_pk => "INT AUTO_INCREMENT PRIMARY KEY",
         ("INT_INC", Postgres) if is_pk => "SERIAL PRIMARY KEY",
@@ -231,7 +231,7 @@ mod test {
     #![allow(unused_imports, dead_code)]
     use super::*;
 
-    /// Canonical list of every gencsv type covered by D1, drawn from PRD §6.2.
+    /// Canonical list of every synthtab type covered by D1, drawn from PRD §6.2.
     /// Used by the contract test in `every_type_has_mapping_for_every_dialect`.
     const SUPPORTED_TYPES: &[&str] = &[
         "INT_INC",

--- a/src/util/generator.rs
+++ b/src/util/generator.rs
@@ -11,7 +11,7 @@
 
 use crate::util::erd_ast::{Cardinality, Entity, ErdAst, Relationship};
 use crate::util::fake::create_column;
-use crate::util::parser::mermaid_type_to_gencsv;
+use crate::util::parser::mermaid_type_to_synthtab;
 use crate::util::schema::Schema;
 use polars::prelude::*;
 use rand::seq::SliceRandom;
@@ -186,7 +186,7 @@ fn build_entity_frame(
             continue;
         }
 
-        let gencsv_type = mermaid_type_to_gencsv(&attr.data_type).ok_or_else(|| GenError {
+        let synthtab_type = mermaid_type_to_synthtab(&attr.data_type).ok_or_else(|| GenError {
             message: format!(
                 "entity '{}': attribute '{}' has unknown type '{}' (parser should have caught this)",
                 entity.name, attr.name, attr.data_type
@@ -195,7 +195,7 @@ fn build_entity_frame(
 
         let schema = Schema {
             name: attr.name.clone(),
-            datatype: gencsv_type.to_string(),
+            datatype: synthtab_type.to_string(),
             modifier: None,
         };
         let col = create_column(schema, n);

--- a/src/util/multi_file_sink.rs
+++ b/src/util/multi_file_sink.rs
@@ -64,7 +64,7 @@ mod test {
 
     #[test]
     fn creates_directory_and_writes_csv() {
-        let tmp = std::env::temp_dir().join("gencsv_msink_csv_test");
+        let tmp = std::env::temp_dir().join("synthtab_msink_csv_test");
         let _ = std::fs::remove_dir_all(&tmp);
         let sink = MultiFileSink::new(tmp.clone(), SinkFormat::Csv).unwrap();
         let mut df = sample_df();
@@ -76,7 +76,7 @@ mod test {
 
     #[test]
     fn creates_directory_and_writes_parquet() {
-        let tmp = std::env::temp_dir().join("gencsv_msink_parquet_test");
+        let tmp = std::env::temp_dir().join("synthtab_msink_parquet_test");
         let _ = std::fs::remove_dir_all(&tmp);
         let sink = MultiFileSink::new(tmp.clone(), SinkFormat::Parquet).unwrap();
         let mut df = sample_df();
@@ -88,7 +88,7 @@ mod test {
 
     #[test]
     fn file_path_combines_out_dir_and_entity_name() {
-        let tmp = std::env::temp_dir().join("gencsv_msink_path_test");
+        let tmp = std::env::temp_dir().join("synthtab_msink_path_test");
         let _ = std::fs::remove_dir_all(&tmp);
         let sink = MultiFileSink::new(tmp.clone(), SinkFormat::Csv).unwrap();
         let mut df = sample_df();

--- a/src/util/output.rs
+++ b/src/util/output.rs
@@ -59,7 +59,7 @@ mod test {
 
     #[test]
     fn test_csv_file_writer_creates_file() {
-        let path = std::env::temp_dir().join("gencsv_test_csv_writer.csv");
+        let path = std::env::temp_dir().join("synthtab_test_csv_writer.csv");
         let mut writer = CSVFile {
             file_name: path.to_str().unwrap().to_string(),
         };
@@ -73,7 +73,7 @@ mod test {
 
     #[test]
     fn test_parquet_file_writer_creates_file() {
-        let path = std::env::temp_dir().join("gencsv_test_parquet_writer.parquet");
+        let path = std::env::temp_dir().join("synthtab_test_parquet_writer.parquet");
         let mut writer = ParquetFile {
             file_name: path.to_str().unwrap().to_string(),
         };

--- a/src/util/parser.rs
+++ b/src/util/parser.rs
@@ -27,11 +27,11 @@ impl fmt::Display for ParseError {
 
 impl Error for ParseError {}
 
-/// Mermaid attribute types accepted by the parser. Maps to the gencsv generator
+/// Mermaid attribute types accepted by the parser. Maps to the synthtab generator
 /// type used at row-generation time (see PRD §6.3). Mermaid `bool`/`boolean`
 /// is intentionally absent: it is detected and rejected with a specific
 /// "not yet supported" message per PRD §7.
-pub(crate) fn mermaid_type_to_gencsv(mermaid: &str) -> Option<&'static str> {
+pub(crate) fn mermaid_type_to_synthtab(mermaid: &str) -> Option<&'static str> {
     let base = mermaid
         .split_once('(')
         .map(|(b, _)| b)
@@ -291,7 +291,7 @@ impl Parser {
                         });
                     }
 
-                    if mermaid_type_to_gencsv(&ty).is_none() {
+                    if mermaid_type_to_synthtab(&ty).is_none() {
                         return Err(ParseError {
                             message: format!(
                                 "line {line}: unknown type '{ty}'; supported types: int, string, uuid, date, datetime, decimal, time (see docs/ERD.md §Types)"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fs;
 type TestResult = Result<(), Box<dyn Error>>;
 
-const NAME: &str = "gencsv";
+const NAME: &str = "synthtab";
 fn run(args: &[&str], expected_file: &str) -> TestResult {
     let expected = fs::read_to_string(expected_file)?;
     Command::cargo_bin(NAME)?

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -98,7 +98,7 @@ fn test_er_subcommand_listed_in_help() -> TestResult {
 
 #[test]
 fn test_er_generates_csv_files_for_valid_fixture() -> TestResult {
-    let out_dir = std::env::temp_dir().join("gencsv_cli_er_fixture_test");
+    let out_dir = std::env::temp_dir().join("synthtab_cli_er_fixture_test");
     let _ = fs::remove_dir_all(&out_dir);
     Command::cargo_bin(NAME)?
         .args([
@@ -120,7 +120,7 @@ fn test_er_generates_csv_files_for_valid_fixture() -> TestResult {
 
 #[test]
 fn test_er_generates_junction_for_many_to_many() -> TestResult {
-    let out_dir = std::env::temp_dir().join("gencsv_cli_er_mn_test");
+    let out_dir = std::env::temp_dir().join("synthtab_cli_er_mn_test");
     let _ = fs::remove_dir_all(&out_dir);
     Command::cargo_bin(NAME)?
         .args([
@@ -179,8 +179,8 @@ fn test_flat_mode_still_works_after_subcommand_refactor() -> TestResult {
 
 #[test]
 fn test_target_postgres_writes_ddl_file() -> TestResult {
-    let data = std::env::temp_dir().join("gencsv_ddl_test_users.csv");
-    let ddl = std::env::temp_dir().join("gencsv_ddl_test_users.ddl.postgres.sql");
+    let data = std::env::temp_dir().join("synthtab_ddl_test_users.csv");
+    let ddl = std::env::temp_dir().join("synthtab_ddl_test_users.ddl.postgres.sql");
     let _ = fs::remove_file(&data);
     let _ = fs::remove_file(&ddl);
     Command::cargo_bin(NAME)?
@@ -220,8 +220,8 @@ fn test_target_without_file_target_is_rejected() -> TestResult {
 
 #[test]
 fn test_target_postgres_writes_load_file() -> TestResult {
-    let data = std::env::temp_dir().join("gencsv_load_test_users.csv");
-    let load = std::env::temp_dir().join("gencsv_load_test_users.load.postgres.sql");
+    let data = std::env::temp_dir().join("synthtab_load_test_users.csv");
+    let load = std::env::temp_dir().join("synthtab_load_test_users.load.postgres.sql");
     let _ = fs::remove_file(&data);
     let _ = fs::remove_file(&load);
     Command::cargo_bin(NAME)?
@@ -252,8 +252,8 @@ fn test_target_postgres_writes_load_file() -> TestResult {
 
 #[test]
 fn test_no_load_suppresses_load_file() -> TestResult {
-    let data = std::env::temp_dir().join("gencsv_no_load_test.csv");
-    let load = std::env::temp_dir().join("gencsv_no_load_test.load.mysql.sql");
+    let data = std::env::temp_dir().join("synthtab_no_load_test.csv");
+    let load = std::env::temp_dir().join("synthtab_no_load_test.load.mysql.sql");
     let _ = fs::remove_file(&data);
     let _ = fs::remove_file(&load);
     Command::cargo_bin(NAME)?
@@ -278,7 +278,7 @@ fn test_no_load_suppresses_load_file() -> TestResult {
 
 #[test]
 fn test_er_target_postgres_writes_ddl_and_load() -> TestResult {
-    let out_dir = std::env::temp_dir().join("gencsv_cli_er_target_test");
+    let out_dir = std::env::temp_dir().join("synthtab_cli_er_target_test");
     let _ = fs::remove_dir_all(&out_dir);
     Command::cargo_bin(NAME)?
         .args([
@@ -312,8 +312,8 @@ fn test_er_target_postgres_writes_ddl_and_load() -> TestResult {
 
 #[test]
 fn test_no_ddl_suppresses_ddl_file() -> TestResult {
-    let data = std::env::temp_dir().join("gencsv_no_ddl_test.csv");
-    let ddl = std::env::temp_dir().join("gencsv_no_ddl_test.ddl.mysql.sql");
+    let data = std::env::temp_dir().join("synthtab_no_ddl_test.csv");
+    let ddl = std::env::temp_dir().join("synthtab_no_ddl_test.ddl.mysql.sql");
     let _ = fs::remove_file(&data);
     let _ = fs::remove_file(&ddl);
     Command::cargo_bin(NAME)?

--- a/tests/fixtures/dialects/users.ddl.postgres.sql
+++ b/tests/fixtures/dialects/users.ddl.postgres.sql
@@ -1,4 +1,4 @@
-CREATE TABLE gencsv_ddl_test_users (
+CREATE TABLE synthtab_ddl_test_users (
   id SERIAL PRIMARY KEY,
   name TEXT,
   joined DATE


### PR DESCRIPTION
Renames the Cargo crate + binary from gencsv (repo gencsvrs) to synthtab, bumps to v0.2.0, and adds crates.io metadata (description, license, repository, keywords, categories) in preparation for the upcoming Homebrew + crates.io + .deb distribution work.

Stacked on docs/readme-examples — merge that PR first; GitHub will auto-retarget this PR to main.

Verified: cargo build, cargo test (19/19), cargo clippy --all-targets -- -D warnings, cargo publish --dry-run all pass.

GitHub repo already renamed jheryer/gencsvrs -> jheryer/synthtab (auto-redirects active).